### PR TITLE
feat: enforce DTOs and Value Objects over array handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is an **Agent Skill** following the [open standard](https://agentskills.io)
 - **PHP 8.x Features**: Constructor property promotion, readonly properties and classes, named arguments, enums and match expressions, attributes (replacing annotations), union and intersection types, nullsafe operator
 - **Static Analysis Tools**: PHPStan (level 9+), PHPat (architecture testing), Rector (automated refactoring), PHP-CS-Fixer (coding style)
 - **PSR/PER Compliance**: Enforces all active PHP-FIG standards (PSR-1, 3, 4, 6, 7, 11, 12, 13, 14, 15, 16, 17, 18, 20) and PER Coding Style
-- **Type Safety Patterns**: Generic collection typing via PHPDoc, ArrayTypeHelper for type-safe array operations, strict typing enforcement, PHPStan level 10 compliance, runtime type validation
+- **Type Safety Patterns**: DTOs and Value Objects over arrays, generic collection typing via PHPDoc, strict typing enforcement, PHPStan level 10 compliance, runtime type validation
 - **Symfony Integration**: Dependency injection patterns, service configuration (YAML to PHP), event dispatcher and PSR-14, form handling modernization, security component updates
 
 ## Installation
@@ -125,11 +125,40 @@ All modern PHP code must follow active PHP-FIG standards:
 - Nullsafe operator
 
 ### Type Safety Patterns
+- **DTOs and Value Objects over arrays** (see below)
 - Generic collection typing via PHPDoc
-- ArrayTypeHelper for type-safe array operations
 - Strict typing enforcement
 - PHPStan level 9+/10 compliance
 - Runtime type validation
+
+### DTOs and Value Objects (Required)
+
+**Never pass or return raw arrays** for structured data. Use typed objects instead:
+
+| Instead of | Use |
+|------------|-----|
+| `array $userData` | `UserDTO $user` |
+| `array{email: string, name: string}` | `readonly class UserDTO` |
+| `array $config` | `readonly class Config` or Value Object |
+| `array $request` | `RequestDTO::fromRequest($request)` |
+| `return ['success' => true, 'data' => $x]` | `return new ResultDTO($x)` |
+
+**Why:**
+- Arrays lack type safety at runtime
+- No IDE autocompletion for array keys
+- PHPStan cannot verify array shapes across boundaries
+- Refactoring arrays is error-prone
+
+**Pattern:**
+```php
+// ❌ Bad: Array passing
+public function createUser(array $data): array
+
+// ✅ Good: DTO pattern
+public function createUser(CreateUserDTO $dto): UserDTO
+```
+
+See `references/request-dtos.md` for complete patterns including Request DTOs, Command/Query DTOs, and Value Objects
 
 ### Symfony Integration
 - Dependency injection patterns
@@ -168,7 +197,9 @@ All modern PHP code must follow active PHP-FIG standards:
 - Add return types to all methods
 - Add parameter types to all methods
 - Use union types instead of mixed
-- Implement ArrayTypeHelper for collections
+- **Replace array parameters with DTOs**
+- **Replace array returns with typed objects**
+- **Use Value Objects for domain concepts (Email, Money, etc.)**
 - Add @template annotations for generics
 - Remove @var annotations where inferrable
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,7 +12,7 @@ Modernize PHP applications to PHP 8.x with type safety, PSR compliance, Symfony 
 - **PHP 8.x**: Constructor promotion, readonly, enums, match, attributes, union types
 - **PSR/PER Compliance**: Active PHP-FIG standards (PSR-1,3,4,6,7,11,12,13,14,15,16,17,18,20, PER Coding Style)
 - **Static Analysis**: PHPStan (level 9+), PHPat, Rector, PHP-CS-Fixer
-- **Type Safety**: Generics via PHPDoc, ArrayTypeHelper, PHPStan level 10 (max)
+- **Type Safety**: DTOs/VOs over arrays, generics via PHPDoc, PHPStan level 10 (max)
 - **Symfony**: DI patterns, PHP config, PSR-14 events
 
 ## Reference Files
@@ -107,6 +107,26 @@ All modern PHP code must follow active PHP-FIG standards:
 
 **Source of truth:** https://www.php-fig.org/psr/ and https://www.php-fig.org/per/
 
+## DTOs and Value Objects (Required)
+
+**Never pass or return raw arrays** for structured data. Use typed objects:
+
+```php
+// ❌ Bad: Array passing
+public function createUser(array $data): array
+
+// ✅ Good: DTO pattern
+public function createUser(CreateUserDTO $dto): UserDTO
+```
+
+| Instead of | Use |
+|------------|-----|
+| `array $userData` | `UserDTO` |
+| `array $config` | `readonly class Config` |
+| `return ['success' => true]` | `return new ResultDTO()` |
+
+See `references/request-dtos.md` for Request DTOs, Command/Query DTOs, and Value Objects.
+
 ## Quick Patterns
 
 **Constructor promotion (PHP 8.0+):**
@@ -155,6 +175,8 @@ public function getUsers(): array
 - [ ] PHPat architecture tests for layer dependencies
 - [ ] Rector with no remaining suggestions
 - [ ] Return types and parameter types on all methods
+- [ ] **DTOs for data transfer, Value Objects for domain concepts**
+- [ ] **No array parameters/returns for structured data**
 - [ ] Replace annotations with attributes
 - [ ] Use readonly, enums, match expressions
 - [ ] Type-hint against PSR interfaces (not implementations)
@@ -168,6 +190,7 @@ public function getUsers(): array
 | Rector | No remaining suggestions |
 | PHP-CS-Fixer | `@PER-CS` with zero violations |
 | PSR Compliance | Type-hint against PSR interfaces |
+| DTOs/VOs | No array params/returns for structured data |
 
 > **Note:** PHPStan level 8 or below is insufficient for production code. Level 9+ enforces strict `mixed` type handling.
 


### PR DESCRIPTION
## Summary

Add explicit requirement that DTOs and Value Objects must be used instead of raw arrays for structured data passing/returning.

## Changes

- Add **DTOs and Value Objects (Required)** section to README and SKILL.md
- Update migration checklist with DTO/VO requirements
- Add DTOs/VOs to scoring criteria
- Update type safety patterns description

## Why

Arrays for structured data have significant drawbacks:
- Lack type safety at runtime
- No IDE autocompletion for array keys
- PHPStan cannot verify array shapes across boundaries
- Refactoring arrays is error-prone

This makes the anti-array pattern an **explicit, enforced requirement** rather than just a suggested practice.