### PR TITLE
feat: enforce backed enums over string/integer constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,57 @@ public function createUser(CreateUserDTO $dto): UserDTO
 
 See `references/request-dtos.md` for complete patterns including Request DTOs, Command/Query DTOs, and Value Objects
 
+### Enums (Required)
+
+**Never use string/integer constants or arrays** for fixed sets of values. Use PHP 8.1+ backed enums instead:
+
+| Instead of | Use |
+|------------|-----|
+| `const STATUS_DRAFT = 'draft'` | `enum Status: string { case Draft = 'draft'; }` |
+| `['draft', 'published', 'archived']` | `Status::cases()` |
+| `string $status` parameter | `Status $status` parameter |
+| `switch ($status)` | `match($status)` with enum |
+
+**Why enums are required:**
+- Compile-time type checking (invalid values caught before runtime)
+- IDE autocompletion for all valid values
+- Exhaustive `match()` enforcement (compiler ensures all cases handled)
+- Methods encapsulate related logic (labels, colors, validation)
+- Self-documenting API with clear valid options
+
+**Pattern:**
+```php
+// ❌ Bad: String constants
+class Order {
+    public const STATUS_DRAFT = 'draft';
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_COMPLETED = 'completed';
+
+    public function setStatus(string $status): void // Any string accepted!
+}
+
+// ✅ Good: Backed enum
+enum OrderStatus: string {
+    case Draft = 'draft';
+    case Pending = 'pending';
+    case Completed = 'completed';
+
+    public function label(): string {
+        return match($this) {
+            self::Draft => 'Draft Order',
+            self::Pending => 'Awaiting Payment',
+            self::Completed => 'Order Complete',
+        };
+    }
+}
+
+class Order {
+    public function setStatus(OrderStatus $status): void // Only valid statuses!
+}
+```
+
+See `references/php8-features.md` for complete enum patterns including methods, validation, and database integration.
+
 ### Symfony Integration
 - Dependency injection patterns
 - Service configuration (YAML to PHP)
@@ -182,7 +233,8 @@ See `references/request-dtos.md` for complete patterns including Request DTOs, C
 - Convert to constructor property promotion
 - Use readonly where applicable
 - Replace switch with match expressions
-- Adopt enums for status/type constants
+- **Replace string/int constants with backed enums**
+- **Use enums for all status, type, and option values**
 
 ### PSR/PER Compliance
 - Configure PSR-4 autoloading in composer.json
@@ -200,6 +252,7 @@ See `references/request-dtos.md` for complete patterns including Request DTOs, C
 - **Replace array parameters with DTOs**
 - **Replace array returns with typed objects**
 - **Use Value Objects for domain concepts (Email, Money, etc.)**
+- **Use backed enums for all fixed value sets (status, type, options)**
 - Add @template annotations for generics
 - Remove @var annotations where inferrable
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -127,6 +127,28 @@ public function createUser(CreateUserDTO $dto): UserDTO
 
 See `references/request-dtos.md` for Request DTOs, Command/Query DTOs, and Value Objects.
 
+## Enums (Required)
+
+**Never use string/integer constants** for fixed sets of values. Use PHP 8.1+ backed enums:
+
+```php
+// ❌ Bad: String constants
+public const STATUS_DRAFT = 'draft';
+public function setStatus(string $status): void
+
+// ✅ Good: Backed enum
+enum Status: string { case Draft = 'draft'; }
+public function setStatus(Status $status): void
+```
+
+| Instead of | Use |
+|------------|-----|
+| `const STATUS_X = 'x'` | `enum Status: string` |
+| `string $status` param | `Status $status` param |
+| `switch ($status)` | `match($status)` with enum |
+
+See `references/php8-features.md` for complete enum patterns.
+
 ## Quick Patterns
 
 **Constructor promotion (PHP 8.0+):**
@@ -177,8 +199,10 @@ public function getUsers(): array
 - [ ] Return types and parameter types on all methods
 - [ ] **DTOs for data transfer, Value Objects for domain concepts**
 - [ ] **No array parameters/returns for structured data**
+- [ ] **Backed enums for all status, type, and option values**
+- [ ] **No string/int constants for fixed value sets**
 - [ ] Replace annotations with attributes
-- [ ] Use readonly, enums, match expressions
+- [ ] Use readonly, match expressions
 - [ ] Type-hint against PSR interfaces (not implementations)
 
 ## Scoring
@@ -191,6 +215,7 @@ public function getUsers(): array
 | PHP-CS-Fixer | `@PER-CS` with zero violations |
 | PSR Compliance | Type-hint against PSR interfaces |
 | DTOs/VOs | No array params/returns for structured data |
+| Enums | Backed enums for all fixed value sets (no string/int constants) |
 
 > **Note:** PHPStan level 8 or below is insufficient for production code. Level 9+ enforces strict `mixed` type handling.
 


### PR DESCRIPTION
## Summary
- Add 'Enums (Required)' section to README.md and SKILL.md
- Require backed enums for all status, type, and option values
- Add enum enforcement to migration checklist
- Add enum criterion to scoring table

## Changes
- README.md: Added comprehensive enum enforcement section with examples
- SKILL.md: Added concise enum enforcement section with scoring

## Why
Backed enums provide:
- Compile-time type checking
- IDE autocompletion
- Exhaustive match() enforcement
- Self-documenting API