### PR TITLE
fix(checkpoints): Build/<tool>/ subdir paths and POSIX ERE in PM-02

### DIFF
--- a/skills/php-modernization/checkpoints.yaml
+++ b/skills/php-modernization/checkpoints.yaml
@@ -8,19 +8,19 @@ mechanical:
   # === PHPSTAN CONFIGURATION ===
   - id: PM-01
     type: command
-    command: "test -f phpstan.neon || test -f Build/phpstan.neon || test -f phpstan.neon.dist"
+    command: "test -f phpstan.neon || test -f Build/phpstan.neon || test -f Build/phpstan/phpstan.neon || test -f phpstan.neon.dist"
     severity: error
-    desc: "PHPStan configuration must exist (phpstan.neon, Build/phpstan.neon, or phpstan.neon.dist)"
+    desc: "PHPStan configuration must exist (phpstan.neon, Build/phpstan.neon, Build/phpstan/phpstan.neon, or phpstan.neon.dist)"
 
   - id: PM-02
     type: command
-    command: "grep -qlE 'level:\\s*(9|1[0-9]|max)' phpstan.neon Build/phpstan.neon phpstan.neon.dist 2>/dev/null"
+    command: "grep -qlE 'level:[[:space:]]*(9|1[0-9]|max)' phpstan.neon Build/phpstan.neon Build/phpstan/phpstan.neon phpstan.neon.dist 2>/dev/null"
     severity: error
     desc: "PHPStan level must be 9 or higher (or max)"
 
   - id: PM-03
     type: contains
-    target: "{phpstan.neon,Build/phpstan.neon}"
+    target: "{phpstan.neon,Build/phpstan.neon,Build/phpstan/phpstan.neon,phpstan.neon.dist}"
     pattern: "treatPhpDocTypesAsCertain: false"
     severity: warning
     desc: "PHPStan should not trust PHPDoc types over runtime"
@@ -64,27 +64,27 @@ mechanical:
   # === RECTOR CONFIGURATION ===
   - id: PM-09
     type: file_exists
-    target: "{rector.php,Build/rector.php}"
+    target: "{rector.php,Build/rector.php,Build/rector/rector.php}"
     severity: warning
     desc: "Rector configuration should exist for automated refactoring"
 
   - id: PM-10
     type: contains
-    target: "{rector.php,Build/rector.php}"
+    target: "{rector.php,Build/rector.php,Build/rector/rector.php}"
     pattern: "LevelSetList"
     severity: warning
     desc: "Rector should use LevelSetList for PHP version upgrades"
 
   - id: PM-11
     type: contains
-    target: "{rector.php,Build/rector.php}"
+    target: "{rector.php,Build/rector.php,Build/rector/rector.php}"
     pattern: "SetList::DEAD_CODE"
     severity: info
     desc: "Rector should include DeadCodeSet rules"
 
   - id: PM-12
     type: contains
-    target: "{rector.php,Build/rector.php}"
+    target: "{rector.php,Build/rector.php,Build/rector/rector.php}"
     pattern: "SetList::CODE_QUALITY"
     severity: info
     desc: "Rector should include CodeQualitySetList rules"

--- a/skills/php-modernization/checkpoints.yaml
+++ b/skills/php-modernization/checkpoints.yaml
@@ -14,7 +14,7 @@ mechanical:
 
   - id: PM-02
     type: command
-    command: "grep -qlE 'level:[[:space:]]*(9|1[0-9]|max)' phpstan.neon Build/phpstan.neon Build/phpstan/phpstan.neon phpstan.neon.dist 2>/dev/null"
+    command: 'for f in phpstan.neon Build/phpstan.neon Build/phpstan/phpstan.neon phpstan.neon.dist; do [ -f "$f" ] && grep -qE "^[[:space:]]*level:[[:space:]]*(9|1[0-9]|max)([[:space:]]|$)" "$f" && exit 0; done; exit 1'
     severity: error
     desc: "PHPStan level must be 9 or higher (or max)"
 


### PR DESCRIPTION
## Summary

Two fixes surfaced while assessing netresearch/t3x-nr-llm:

### 1. Accept \`Build/<tool>/\` subdirectory layouts

Many Netresearch extensions keep PHPStan / Rector config under \`Build/phpstan/phpstan.neon\` and \`Build/rector/rector.php\`. PM-01/02/03 and PM-09..12 only looked at \`{root, Build/}\` and failed on every project using the Build/<tool>/ split.

Extended all these checkpoints' target lists / command paths to include \`Build/phpstan/phpstan.neon\` and \`Build/rector/rector.php\`.

### 2. PM-02 used PCRE \`\\s\` in a \`grep -E\` command

\`\\s\` is PCRE-only; \`grep -E\` (POSIX ERE) doesn't interpret it as whitespace — so the pattern \`level:\\s*(9|...)\` never matched in ERE mode. Switch to \`[[:space:]]\` which is POSIX-portable.

Verified: on t3x-nr-llm (level 10), PM-02 previously always failed; now it passes.

## Verification

Against netresearch/t3x-nr-llm:

| Checkpoint | Before | After |
|---|---|---|
| PM-01 phpstan config exists | error — command failed | pass |
| PM-02 phpstan level ≥9 | error — never matched (\\s bug) | pass |
| PM-09 rector.php exists | warning — not found | pass |
| PM-10 LevelSetList | warning — pattern not found | pass |
| PM-12 CODE_QUALITY | info — pattern not found | pass |

## Test plan

- [ ] CI green
- [x] Manual: 19/28 pass now vs. ~10/28 before