### PR TITLE
test: add fixtures and golden-output regression suite for the verifier

### DIFF
--- a/.github/workflows/fixtures-test.yml
+++ b/.github/workflows/fixtures-test.yml
@@ -1,0 +1,40 @@
+---
+name: Fixtures Regression
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  fixtures:
+    name: Verifier snapshot diff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Run fixture regression suite
+        id: fixtures
+        run: uv run scripts/test_fixtures.py | tee fixtures-test-output.txt
+
+      - name: Upload diff on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: fixtures-test-diff-${{ github.run_id }}
+          path: fixtures-test-output.txt
+          if-no-files-found: warn

--- a/.github/workflows/fixtures-test.yml
+++ b/.github/workflows/fixtures-test.yml
@@ -15,25 +15,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
         with:
           enable-cache: true
 
       - name: Run fixture regression suite
         id: fixtures
-        run: uv run scripts/test_fixtures.py | tee fixtures-test-output.txt
+        shell: bash
+        run: |
+          set -o pipefail
+          uv run scripts/test_fixtures.py | tee fixtures-test-output.txt
 
       - name: Upload diff on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: fixtures-test-diff-${{ github.run_id }}
           path: fixtures-test-output.txt

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,87 @@
+# Verifier Regression Fixtures
+
+Synthetic project fixtures and golden-output snapshots used by
+`scripts/test_fixtures.py` to detect unintended changes in the
+`verify_php_project.py` mechanical verifier.
+
+## Layout
+
+Each fixture is a directory under `fixtures/` shaped like a real PHP project,
+with a `expected/verifier.json` snapshot capturing the verifier's output for
+that shape:
+
+| Fixture | Purpose | Detected archetype |
+| --- | --- | --- |
+| `generic-composer-minimal/` | Bare-bones library with `src/` + `tests/` and PSR-4 autoload. Most checks fail; PM-19 (PSR-4) passes. | `generic-composer` |
+| `symfony-app-minimal/` | Minimal Symfony 7 app shape (`bin/console` + `config/bundles.php` + `src/Controller/`). | `symfony-app` |
+| `typo3-extension-minimal/` | Minimal TYPO3 extension (`ext_emconf.php`, `Configuration/Services.yaml`, `Classes/`). | `typo3-extension` |
+| `monorepo-minimal/` | Top-level project with `packages/foo` and `packages/bar` each carrying their own `composer.json`. | `monorepo-package` |
+| `fully-modern/` | Positive control: phpstan.neon (level: max + treatPhpDocTypesAsCertain: false), `.php-cs-fixer.dist.php` (@PER-CS), `rector.php`, composer scripts, and dev-deps for phpstan / php-cs-fixer / rector / phpat. **All checks pass.** | `generic-composer` |
+
+The fixture content is kept minimal but realistic so an agent can use any of
+them as a starting-point reference.
+
+## Snapshot determinism
+
+`verify_php_project.py` emits a few fields that vary between runs or hosts. To
+make snapshots stable, `scripts/test_fixtures.py` applies an idempotent
+normalization pass to *both* the live verifier output and the loaded snapshot
+before diffing:
+
+| Field | Treatment |
+| --- | --- |
+| `generated_at` | Replaced with the literal string `"<NORMALIZED>"`. |
+| `project_root` | Replaced with `"<NORMALIZED>"` (absolute path differs per checkout). |
+| `environment.php_runtime` | Replaced with `"<NORMALIZED>"` (varies per runner; can also be `"unknown"` if `php` is not on PATH). |
+| `tool_runs[]` | Replaced with `[]` — these are subprocess outcomes, not deterministic. The runner invokes the verifier with `--no-tools`, so this should already be empty, but the normalization makes the contract explicit. |
+| `checks[]` | Sorted by `id`. |
+| `agent_actions[]` | Sorted by `checkpoint`. |
+
+The runner uses `--no-tools --no-cache` to keep evaluation fast and free of
+side effects. With `--no-tools` no `.build/` artifact directory is created in
+the fixture tree.
+
+## Running the regression tests
+
+From the repo root:
+
+```sh
+uv run scripts/test_fixtures.py                     # diff all fixtures
+uv run scripts/test_fixtures.py --fixture <name>    # one fixture only
+uv run scripts/test_fixtures.py --update            # regenerate snapshots
+```
+
+Exit code is `0` when all fixtures match their snapshots, `1` otherwise, `2`
+on harness errors (verifier missing, unknown fixture name, etc.).
+
+## When to update snapshots
+
+Use `--update` only when the verifier output legitimately changed and you
+intend the new shape to become the contract. Common triggers:
+
+- A new mechanical check (PM-NN) was added.
+- An existing check's `message`, `severity`, or `evidence` shape changed.
+- `skill_version` was bumped (the version is hardcoded in the verifier source
+  and appears in every snapshot — every release of the skill regenerates all
+  snapshots; this is expected).
+- An `agent_actions[]` entry's `target` / `operation` / `rationale` changed.
+
+Before running `--update`, confirm the diff is intentional. Review the
+resulting `git diff fixtures/*/expected/verifier.json` and commit alongside
+the verifier change so reviewers see the contract evolve in lockstep.
+
+## Adding a new fixture
+
+1. Create a directory under `fixtures/<name>/` with the project files.
+   - The fixture **must** include a `composer.json` (the runner discovers
+     fixtures by this marker).
+   - Make sure no archetype-detection markers from earlier-priority archetypes
+     leak in (TYPO3 markers > Symfony markers > monorepo > generic). For
+     example, a `symfony-app` fixture must not contain `ext_emconf.php`.
+   - Every `.php` file should `declare(strict_types=1);`.
+2. Run `uv run scripts/test_fixtures.py --update --fixture <name>` to write
+   the initial `expected/verifier.json`.
+3. Inspect the snapshot manually — confirm the archetype and pass/fail set
+   match what you intended to capture.
+4. Run `uv run scripts/test_fixtures.py` (without `--update`) to confirm the
+   snapshot diffs cleanly.

--- a/fixtures/fully-modern/.php-cs-fixer.dist.php
+++ b/fixtures/fully-modern/.php-cs-fixer.dist.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__ . '/src');
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PER-CS' => true,
+        'declare_strict_types' => true,
+    ])
+    ->setFinder($finder);

--- a/fixtures/fully-modern/composer.json
+++ b/fixtures/fully-modern/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "fixtures/fully-modern",
+    "description": "Positive-control fixture: passes all mechanical verifier checks.",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.3"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^2.0",
+        "friendsofphp/php-cs-fixer": "^3.64",
+        "rector/rector": "^2.0",
+        "phpat/phpat": "^0.10"
+    },
+    "autoload": {
+        "psr-4": {
+            "Fixtures\\FullyModern\\": "src/"
+        }
+    },
+    "scripts": {
+        "cs:fix": "php-cs-fixer fix",
+        "phpstan": "phpstan analyse",
+        "rector": "rector process"
+    }
+}

--- a/fixtures/fully-modern/expected/verifier.json
+++ b/fixtures/fully-modern/expected/verifier.json
@@ -1,0 +1,182 @@
+{
+  "agent_actions": [],
+  "archetype": "generic-composer",
+  "checks": [
+    {
+      "category": "phpstan",
+      "evidence": [
+        "phpstan.neon"
+      ],
+      "id": "PM-01",
+      "message": "PHPStan configuration found at phpstan.neon",
+      "severity": "error",
+      "status": "pass"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [
+        "phpstan.neon"
+      ],
+      "id": "PM-02",
+      "message": "PHPStan level is 'max' (>= 9 / max)",
+      "severity": "error",
+      "status": "pass"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [
+        "phpstan.neon"
+      ],
+      "id": "PM-03",
+      "message": "treatPhpDocTypesAsCertain is set to false",
+      "severity": "warning",
+      "status": "pass"
+    },
+    {
+      "category": "php-cs-fixer",
+      "evidence": [
+        ".php-cs-fixer.dist.php"
+      ],
+      "id": "PM-04",
+      "message": "PHP-CS-Fixer config found at .php-cs-fixer.dist.php",
+      "severity": "error",
+      "status": "pass"
+    },
+    {
+      "category": "php-cs-fixer",
+      "evidence": [
+        ".php-cs-fixer.dist.php"
+      ],
+      "id": "PM-05",
+      "message": "@PER-CS ruleset is enabled",
+      "severity": "error",
+      "status": "pass"
+    },
+    {
+      "category": "rector",
+      "evidence": [
+        "rector.php"
+      ],
+      "id": "PM-09",
+      "message": "Rector config found at rector.php",
+      "severity": "warning",
+      "status": "pass"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-13",
+      "message": "composer script 'cs:fix' is defined",
+      "severity": "warning",
+      "status": "pass"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-14",
+      "message": "composer script 'phpstan' is defined",
+      "severity": "warning",
+      "status": "pass"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-15",
+      "message": "composer script 'rector' is defined",
+      "severity": "info",
+      "status": "pass"
+    },
+    {
+      "category": "dependencies",
+      "evidence": [],
+      "id": "PM-16",
+      "message": "PHPStan is available (binary or composer dependency)",
+      "severity": "warning",
+      "status": "pass"
+    },
+    {
+      "category": "dependencies",
+      "evidence": [],
+      "id": "PM-17",
+      "message": "PHP-CS-Fixer is available (binary or composer dependency)",
+      "severity": "warning",
+      "status": "pass"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-19",
+      "message": "PSR-4 autoload defined (1 namespace mapping(s))",
+      "severity": "error",
+      "status": "pass"
+    },
+    {
+      "category": "architecture",
+      "evidence": [],
+      "id": "PM-25",
+      "message": "phpat is referenced in composer dependencies",
+      "severity": "info",
+      "status": "pass"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [
+        "phpstan.neon"
+      ],
+      "id": "PM-53",
+      "message": "PHPStan level is 'max' (max)",
+      "severity": "warning",
+      "status": "pass"
+    }
+  ],
+  "environment": {
+    "composer_json": true,
+    "composer_lock": false,
+    "php_runtime": "<NORMALIZED>",
+    "php_version_constraint": "^8.3"
+  },
+  "generated_at": "<NORMALIZED>",
+  "project_root": "<NORMALIZED>",
+  "schema_version": "1.0.0",
+  "skill": "php-modernization",
+  "skill_version": "1.16.0",
+  "summary": {
+    "errors": 0,
+    "info": 0,
+    "status": "pass",
+    "warnings": 0
+  },
+  "tool_runs": [],
+  "tooling": {
+    "composer_audit_supported": false,
+    "infection": {
+      "configured": false
+    },
+    "php_cs_fixer": {
+      "config_file": ".php-cs-fixer.dist.php",
+      "configured": true,
+      "ruleset_includes_per_cs": true
+    },
+    "phpat": {
+      "configured": true
+    },
+    "phpstan": {
+      "baseline": null,
+      "config_file": "phpstan.neon",
+      "configured": true,
+      "level": "max"
+    },
+    "rector": {
+      "config_file": "rector.php",
+      "configured": true
+    }
+  }
+}

--- a/fixtures/fully-modern/expected/verifier.json
+++ b/fixtures/fully-modern/expected/verifier.json
@@ -147,7 +147,7 @@
   "project_root": "<NORMALIZED>",
   "schema_version": "1.0.0",
   "skill": "php-modernization",
-  "skill_version": "1.16.0",
+  "skill_version": "1.17.0",
   "summary": {
     "errors": 0,
     "info": 0,

--- a/fixtures/fully-modern/phpstan.neon
+++ b/fixtures/fully-modern/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: max
+    treatPhpDocTypesAsCertain: false
+    paths:
+        - src

--- a/fixtures/fully-modern/rector.php
+++ b/fixtures/fully-modern/rector.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return RectorConfig::configure()
+    ->withPaths([__DIR__ . '/src'])
+    ->withSets([LevelSetList::UP_TO_PHP_83]);

--- a/fixtures/fully-modern/src/Modern.php
+++ b/fixtures/fully-modern/src/Modern.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\FullyModern;
+
+final readonly class Modern
+{
+    public function __construct(
+        private string $label,
+    ) {
+    }
+
+    public function label(): string
+    {
+        return $this->label;
+    }
+}

--- a/fixtures/fully-modern/tests/ModernTest.php
+++ b/fixtures/fully-modern/tests/ModernTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\FullyModern\Tests;
+
+use Fixtures\FullyModern\Modern;
+use PHPUnit\Framework\TestCase;
+
+final class ModernTest extends TestCase
+{
+    public function testLabel(): void
+    {
+        self::assertSame('hello', (new Modern('hello'))->label());
+    }
+}

--- a/fixtures/generic-composer-minimal/composer.json
+++ b/fixtures/generic-composer-minimal/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "fixtures/generic-composer-minimal",
+    "description": "Minimal generic Composer project for verifier regression tests.",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Fixtures\\GenericComposerMinimal\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Fixtures\\GenericComposerMinimal\\Tests\\": "tests/"
+        }
+    }
+}

--- a/fixtures/generic-composer-minimal/expected/verifier.json
+++ b/fixtures/generic-composer-minimal/expected/verifier.json
@@ -218,7 +218,7 @@
   "project_root": "<NORMALIZED>",
   "schema_version": "1.0.0",
   "skill": "php-modernization",
-  "skill_version": "1.16.0",
+  "skill_version": "1.17.0",
   "summary": {
     "errors": 2,
     "info": 2,

--- a/fixtures/generic-composer-minimal/expected/verifier.json
+++ b/fixtures/generic-composer-minimal/expected/verifier.json
@@ -1,0 +1,253 @@
+{
+  "agent_actions": [
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-01",
+      "confirm_required": false,
+      "operation": "create_phpstan_config",
+      "rationale": "PHPStan must be configured (phpstan.neon or phpstan.neon.dist)",
+      "target": "phpstan.neon"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-04",
+      "confirm_required": false,
+      "operation": "create_php_cs_fixer_config",
+      "rationale": "PHP-CS-Fixer must be configured to enforce coding standards",
+      "target": ".php-cs-fixer.dist.php"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-09",
+      "confirm_required": false,
+      "operation": "create_rector_config",
+      "rationale": "Rector enables automated refactoring for PHP version upgrades",
+      "target": "rector.php"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-13",
+      "confirm_required": false,
+      "operation": "add_cs_fix_script",
+      "rationale": "Coding-standards fix script makes the toolchain runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-14",
+      "confirm_required": false,
+      "operation": "add_phpstan_script",
+      "rationale": "PHPStan script makes static analysis runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-15",
+      "confirm_required": false,
+      "operation": "add_rector_script",
+      "rationale": "Rector script makes automated refactoring runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-16",
+      "confirm_required": false,
+      "operation": "require_dev_phpstan",
+      "rationale": "Add phpstan/phpstan to require-dev or rely on a transitive CI package",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-17",
+      "confirm_required": false,
+      "operation": "require_dev_php_cs_fixer",
+      "rationale": "Add friendsofphp/php-cs-fixer to require-dev or rely on a transitive CI package",
+      "target": "composer.json"
+    },
+    {
+      "action": "read_reference",
+      "checkpoint": "PM-25",
+      "confirm_required": false,
+      "operation": "introduce_phpat",
+      "rationale": "phpat enforces architectural rules in CI",
+      "target": "skills/php-modernization/references/static-analysis-tools.md"
+    }
+  ],
+  "archetype": "generic-composer",
+  "checks": [
+    {
+      "category": "phpstan",
+      "evidence": [
+        "phpstan.neon",
+        "phpstan.neon.dist",
+        "Build/phpstan.neon",
+        "Build/phpstan/phpstan.neon"
+      ],
+      "id": "PM-01",
+      "message": "PHPStan configuration is missing",
+      "severity": "error",
+      "status": "fail"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-02",
+      "message": "PHPStan configuration not found; level cannot be evaluated",
+      "severity": "error",
+      "status": "skipped"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-03",
+      "message": "PHPStan configuration not found",
+      "severity": "warning",
+      "status": "skipped"
+    },
+    {
+      "category": "php-cs-fixer",
+      "evidence": [
+        ".php-cs-fixer.php",
+        ".php-cs-fixer.dist.php"
+      ],
+      "id": "PM-04",
+      "message": "PHP-CS-Fixer configuration is missing",
+      "severity": "error",
+      "status": "fail"
+    },
+    {
+      "category": "php-cs-fixer",
+      "evidence": [],
+      "id": "PM-05",
+      "message": "PHP-CS-Fixer configuration not found",
+      "severity": "error",
+      "status": "skipped"
+    },
+    {
+      "category": "rector",
+      "evidence": [
+        "rector.php",
+        "Build/rector.php",
+        "Build/rector/rector.php"
+      ],
+      "id": "PM-09",
+      "message": "Rector configuration is missing",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-13",
+      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix) found in composer.json",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-14",
+      "message": "No PHPStan script (phpstan/analyse/analyze) found in composer.json",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-15",
+      "message": "No Rector script (rector/refactor) found in composer.json",
+      "severity": "info",
+      "status": "fail"
+    },
+    {
+      "category": "dependencies",
+      "evidence": [],
+      "id": "PM-16",
+      "message": "PHPStan is not available \u2014 neither binary nor composer dependency detected",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "dependencies",
+      "evidence": [],
+      "id": "PM-17",
+      "message": "PHP-CS-Fixer is not available \u2014 neither binary nor composer dependency detected",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-19",
+      "message": "PSR-4 autoload defined (1 namespace mapping(s))",
+      "severity": "error",
+      "status": "pass"
+    },
+    {
+      "category": "architecture",
+      "evidence": [],
+      "id": "PM-25",
+      "message": "phpat is not configured \u2014 architecture tests recommended",
+      "severity": "info",
+      "status": "fail"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-53",
+      "message": "PHPStan configuration not found",
+      "severity": "warning",
+      "status": "skipped"
+    }
+  ],
+  "environment": {
+    "composer_json": true,
+    "composer_lock": false,
+    "php_runtime": "<NORMALIZED>",
+    "php_version_constraint": "^8.2"
+  },
+  "generated_at": "<NORMALIZED>",
+  "project_root": "<NORMALIZED>",
+  "schema_version": "1.0.0",
+  "skill": "php-modernization",
+  "skill_version": "1.16.0",
+  "summary": {
+    "errors": 2,
+    "info": 2,
+    "status": "fail",
+    "warnings": 5
+  },
+  "tool_runs": [],
+  "tooling": {
+    "composer_audit_supported": false,
+    "infection": {
+      "configured": false
+    },
+    "php_cs_fixer": {
+      "config_file": null,
+      "configured": false,
+      "ruleset_includes_per_cs": false
+    },
+    "phpat": {
+      "configured": false
+    },
+    "phpstan": {
+      "baseline": null,
+      "config_file": null,
+      "configured": false,
+      "level": null
+    },
+    "rector": {
+      "config_file": null,
+      "configured": false
+    }
+  }
+}

--- a/fixtures/generic-composer-minimal/src/Foo.php
+++ b/fixtures/generic-composer-minimal/src/Foo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\GenericComposerMinimal;
+
+final class Foo
+{
+    public function greet(string $name): string
+    {
+        return 'Hello, ' . $name;
+    }
+}

--- a/fixtures/generic-composer-minimal/tests/FooTest.php
+++ b/fixtures/generic-composer-minimal/tests/FooTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\GenericComposerMinimal\Tests;
+
+use Fixtures\GenericComposerMinimal\Foo;
+use PHPUnit\Framework\TestCase;
+
+final class FooTest extends TestCase
+{
+    public function testGreet(): void
+    {
+        self::assertSame('Hello, world', (new Foo())->greet('world'));
+    }
+}

--- a/fixtures/monorepo-minimal/composer.json
+++ b/fixtures/monorepo-minimal/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "fixtures/monorepo-minimal",
+    "description": "Monorepo fixture with packages/ subdirectories for verifier regression tests.",
+    "type": "project",
+    "license": "MIT",
+    "require": {
+        "php": "^8.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Fixtures\\MonorepoMinimal\\": "src/"
+        }
+    },
+    "repositories": [
+        {"type": "path", "url": "packages/foo"},
+        {"type": "path", "url": "packages/bar"}
+    ]
+}

--- a/fixtures/monorepo-minimal/expected/verifier.json
+++ b/fixtures/monorepo-minimal/expected/verifier.json
@@ -1,0 +1,253 @@
+{
+  "agent_actions": [
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-01",
+      "confirm_required": false,
+      "operation": "create_phpstan_config",
+      "rationale": "PHPStan must be configured (phpstan.neon or phpstan.neon.dist)",
+      "target": "phpstan.neon"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-04",
+      "confirm_required": false,
+      "operation": "create_php_cs_fixer_config",
+      "rationale": "PHP-CS-Fixer must be configured to enforce coding standards",
+      "target": ".php-cs-fixer.dist.php"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-09",
+      "confirm_required": false,
+      "operation": "create_rector_config",
+      "rationale": "Rector enables automated refactoring for PHP version upgrades",
+      "target": "rector.php"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-13",
+      "confirm_required": false,
+      "operation": "add_cs_fix_script",
+      "rationale": "Coding-standards fix script makes the toolchain runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-14",
+      "confirm_required": false,
+      "operation": "add_phpstan_script",
+      "rationale": "PHPStan script makes static analysis runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-15",
+      "confirm_required": false,
+      "operation": "add_rector_script",
+      "rationale": "Rector script makes automated refactoring runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-16",
+      "confirm_required": false,
+      "operation": "require_dev_phpstan",
+      "rationale": "Add phpstan/phpstan to require-dev or rely on a transitive CI package",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-17",
+      "confirm_required": false,
+      "operation": "require_dev_php_cs_fixer",
+      "rationale": "Add friendsofphp/php-cs-fixer to require-dev or rely on a transitive CI package",
+      "target": "composer.json"
+    },
+    {
+      "action": "read_reference",
+      "checkpoint": "PM-25",
+      "confirm_required": false,
+      "operation": "introduce_phpat",
+      "rationale": "phpat enforces architectural rules in CI",
+      "target": "skills/php-modernization/references/static-analysis-tools.md"
+    }
+  ],
+  "archetype": "monorepo-package",
+  "checks": [
+    {
+      "category": "phpstan",
+      "evidence": [
+        "phpstan.neon",
+        "phpstan.neon.dist",
+        "Build/phpstan.neon",
+        "Build/phpstan/phpstan.neon"
+      ],
+      "id": "PM-01",
+      "message": "PHPStan configuration is missing",
+      "severity": "error",
+      "status": "fail"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-02",
+      "message": "PHPStan configuration not found; level cannot be evaluated",
+      "severity": "error",
+      "status": "skipped"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-03",
+      "message": "PHPStan configuration not found",
+      "severity": "warning",
+      "status": "skipped"
+    },
+    {
+      "category": "php-cs-fixer",
+      "evidence": [
+        ".php-cs-fixer.php",
+        ".php-cs-fixer.dist.php"
+      ],
+      "id": "PM-04",
+      "message": "PHP-CS-Fixer configuration is missing",
+      "severity": "error",
+      "status": "fail"
+    },
+    {
+      "category": "php-cs-fixer",
+      "evidence": [],
+      "id": "PM-05",
+      "message": "PHP-CS-Fixer configuration not found",
+      "severity": "error",
+      "status": "skipped"
+    },
+    {
+      "category": "rector",
+      "evidence": [
+        "rector.php",
+        "Build/rector.php",
+        "Build/rector/rector.php"
+      ],
+      "id": "PM-09",
+      "message": "Rector configuration is missing",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-13",
+      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix) found in composer.json",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-14",
+      "message": "No PHPStan script (phpstan/analyse/analyze) found in composer.json",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-15",
+      "message": "No Rector script (rector/refactor) found in composer.json",
+      "severity": "info",
+      "status": "fail"
+    },
+    {
+      "category": "dependencies",
+      "evidence": [],
+      "id": "PM-16",
+      "message": "PHPStan is not available \u2014 neither binary nor composer dependency detected",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "dependencies",
+      "evidence": [],
+      "id": "PM-17",
+      "message": "PHP-CS-Fixer is not available \u2014 neither binary nor composer dependency detected",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-19",
+      "message": "PSR-4 autoload defined (1 namespace mapping(s))",
+      "severity": "error",
+      "status": "pass"
+    },
+    {
+      "category": "architecture",
+      "evidence": [],
+      "id": "PM-25",
+      "message": "phpat is not configured \u2014 architecture tests recommended",
+      "severity": "info",
+      "status": "fail"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-53",
+      "message": "PHPStan configuration not found",
+      "severity": "warning",
+      "status": "skipped"
+    }
+  ],
+  "environment": {
+    "composer_json": true,
+    "composer_lock": false,
+    "php_runtime": "<NORMALIZED>",
+    "php_version_constraint": "^8.2"
+  },
+  "generated_at": "<NORMALIZED>",
+  "project_root": "<NORMALIZED>",
+  "schema_version": "1.0.0",
+  "skill": "php-modernization",
+  "skill_version": "1.16.0",
+  "summary": {
+    "errors": 2,
+    "info": 2,
+    "status": "fail",
+    "warnings": 5
+  },
+  "tool_runs": [],
+  "tooling": {
+    "composer_audit_supported": false,
+    "infection": {
+      "configured": false
+    },
+    "php_cs_fixer": {
+      "config_file": null,
+      "configured": false,
+      "ruleset_includes_per_cs": false
+    },
+    "phpat": {
+      "configured": false
+    },
+    "phpstan": {
+      "baseline": null,
+      "config_file": null,
+      "configured": false,
+      "level": null
+    },
+    "rector": {
+      "config_file": null,
+      "configured": false
+    }
+  }
+}

--- a/fixtures/monorepo-minimal/expected/verifier.json
+++ b/fixtures/monorepo-minimal/expected/verifier.json
@@ -218,7 +218,7 @@
   "project_root": "<NORMALIZED>",
   "schema_version": "1.0.0",
   "skill": "php-modernization",
-  "skill_version": "1.16.0",
+  "skill_version": "1.17.0",
   "summary": {
     "errors": 2,
     "info": 2,

--- a/fixtures/monorepo-minimal/packages/bar/composer.json
+++ b/fixtures/monorepo-minimal/packages/bar/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "fixtures/monorepo-minimal-bar",
+    "description": "Monorepo sub-package: bar.",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Fixtures\\MonorepoMinimal\\Bar\\": "src/"
+        }
+    }
+}

--- a/fixtures/monorepo-minimal/packages/foo/composer.json
+++ b/fixtures/monorepo-minimal/packages/foo/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "fixtures/monorepo-minimal-foo",
+    "description": "Monorepo sub-package: foo.",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Fixtures\\MonorepoMinimal\\Foo\\": "src/"
+        }
+    }
+}

--- a/fixtures/symfony-app-minimal/bin/console
+++ b/fixtures/symfony-app-minimal/bin/console
@@ -1,0 +1,7 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+// Symfony console marker file (fixture shape only — not executable).
+exit(0);

--- a/fixtures/symfony-app-minimal/composer.json
+++ b/fixtures/symfony-app-minimal/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "fixtures/symfony-app-minimal",
+    "description": "Minimal Symfony 7 app shape for verifier regression tests.",
+    "type": "project",
+    "license": "MIT",
+    "require": {
+        "php": "^8.2",
+        "symfony/framework-bundle": "^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}

--- a/fixtures/symfony-app-minimal/config/bundles.php
+++ b/fixtures/symfony-app-minimal/config/bundles.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+];

--- a/fixtures/symfony-app-minimal/expected/verifier.json
+++ b/fixtures/symfony-app-minimal/expected/verifier.json
@@ -1,0 +1,253 @@
+{
+  "agent_actions": [
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-01",
+      "confirm_required": false,
+      "operation": "create_phpstan_config",
+      "rationale": "PHPStan must be configured (phpstan.neon or phpstan.neon.dist)",
+      "target": "phpstan.neon"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-04",
+      "confirm_required": false,
+      "operation": "create_php_cs_fixer_config",
+      "rationale": "PHP-CS-Fixer must be configured to enforce coding standards",
+      "target": ".php-cs-fixer.dist.php"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-09",
+      "confirm_required": false,
+      "operation": "create_rector_config",
+      "rationale": "Rector enables automated refactoring for PHP version upgrades",
+      "target": "rector.php"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-13",
+      "confirm_required": false,
+      "operation": "add_cs_fix_script",
+      "rationale": "Coding-standards fix script makes the toolchain runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-14",
+      "confirm_required": false,
+      "operation": "add_phpstan_script",
+      "rationale": "PHPStan script makes static analysis runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-15",
+      "confirm_required": false,
+      "operation": "add_rector_script",
+      "rationale": "Rector script makes automated refactoring runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-16",
+      "confirm_required": false,
+      "operation": "require_dev_phpstan",
+      "rationale": "Add phpstan/phpstan to require-dev or rely on a transitive CI package",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-17",
+      "confirm_required": false,
+      "operation": "require_dev_php_cs_fixer",
+      "rationale": "Add friendsofphp/php-cs-fixer to require-dev or rely on a transitive CI package",
+      "target": "composer.json"
+    },
+    {
+      "action": "read_reference",
+      "checkpoint": "PM-25",
+      "confirm_required": false,
+      "operation": "introduce_phpat",
+      "rationale": "phpat enforces architectural rules in CI",
+      "target": "skills/php-modernization/references/static-analysis-tools.md"
+    }
+  ],
+  "archetype": "symfony-app",
+  "checks": [
+    {
+      "category": "phpstan",
+      "evidence": [
+        "phpstan.neon",
+        "phpstan.neon.dist",
+        "Build/phpstan.neon",
+        "Build/phpstan/phpstan.neon"
+      ],
+      "id": "PM-01",
+      "message": "PHPStan configuration is missing",
+      "severity": "error",
+      "status": "fail"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-02",
+      "message": "PHPStan configuration not found; level cannot be evaluated",
+      "severity": "error",
+      "status": "skipped"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-03",
+      "message": "PHPStan configuration not found",
+      "severity": "warning",
+      "status": "skipped"
+    },
+    {
+      "category": "php-cs-fixer",
+      "evidence": [
+        ".php-cs-fixer.php",
+        ".php-cs-fixer.dist.php"
+      ],
+      "id": "PM-04",
+      "message": "PHP-CS-Fixer configuration is missing",
+      "severity": "error",
+      "status": "fail"
+    },
+    {
+      "category": "php-cs-fixer",
+      "evidence": [],
+      "id": "PM-05",
+      "message": "PHP-CS-Fixer configuration not found",
+      "severity": "error",
+      "status": "skipped"
+    },
+    {
+      "category": "rector",
+      "evidence": [
+        "rector.php",
+        "Build/rector.php",
+        "Build/rector/rector.php"
+      ],
+      "id": "PM-09",
+      "message": "Rector configuration is missing",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-13",
+      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix) found in composer.json",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-14",
+      "message": "No PHPStan script (phpstan/analyse/analyze) found in composer.json",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-15",
+      "message": "No Rector script (rector/refactor) found in composer.json",
+      "severity": "info",
+      "status": "fail"
+    },
+    {
+      "category": "dependencies",
+      "evidence": [],
+      "id": "PM-16",
+      "message": "PHPStan is not available \u2014 neither binary nor composer dependency detected",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "dependencies",
+      "evidence": [],
+      "id": "PM-17",
+      "message": "PHP-CS-Fixer is not available \u2014 neither binary nor composer dependency detected",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-19",
+      "message": "PSR-4 autoload defined (1 namespace mapping(s))",
+      "severity": "error",
+      "status": "pass"
+    },
+    {
+      "category": "architecture",
+      "evidence": [],
+      "id": "PM-25",
+      "message": "phpat is not configured \u2014 architecture tests recommended",
+      "severity": "info",
+      "status": "fail"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-53",
+      "message": "PHPStan configuration not found",
+      "severity": "warning",
+      "status": "skipped"
+    }
+  ],
+  "environment": {
+    "composer_json": true,
+    "composer_lock": false,
+    "php_runtime": "<NORMALIZED>",
+    "php_version_constraint": "^8.2"
+  },
+  "generated_at": "<NORMALIZED>",
+  "project_root": "<NORMALIZED>",
+  "schema_version": "1.0.0",
+  "skill": "php-modernization",
+  "skill_version": "1.16.0",
+  "summary": {
+    "errors": 2,
+    "info": 2,
+    "status": "fail",
+    "warnings": 5
+  },
+  "tool_runs": [],
+  "tooling": {
+    "composer_audit_supported": false,
+    "infection": {
+      "configured": false
+    },
+    "php_cs_fixer": {
+      "config_file": null,
+      "configured": false,
+      "ruleset_includes_per_cs": false
+    },
+    "phpat": {
+      "configured": false
+    },
+    "phpstan": {
+      "baseline": null,
+      "config_file": null,
+      "configured": false,
+      "level": null
+    },
+    "rector": {
+      "config_file": null,
+      "configured": false
+    }
+  }
+}

--- a/fixtures/symfony-app-minimal/expected/verifier.json
+++ b/fixtures/symfony-app-minimal/expected/verifier.json
@@ -218,7 +218,7 @@
   "project_root": "<NORMALIZED>",
   "schema_version": "1.0.0",
   "skill": "php-modernization",
-  "skill_version": "1.16.0",
+  "skill_version": "1.17.0",
   "summary": {
     "errors": 2,
     "info": 2,

--- a/fixtures/symfony-app-minimal/src/Controller/Foo.php
+++ b/fixtures/symfony-app-minimal/src/Controller/Foo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+final class Foo
+{
+    public function index(): string
+    {
+        return 'ok';
+    }
+}

--- a/fixtures/typo3-extension-minimal/Classes/Domain/Model/Foo.php
+++ b/fixtures/typo3-extension-minimal/Classes/Domain/Model/Foo.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Typo3ExtensionMinimal\Domain\Model;
+
+final class Foo
+{
+    public function __construct(
+        private readonly string $name,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/fixtures/typo3-extension-minimal/Configuration/Services.yaml
+++ b/fixtures/typo3-extension-minimal/Configuration/Services.yaml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  Fixtures\Typo3ExtensionMinimal\:
+    resource: '../Classes/*'

--- a/fixtures/typo3-extension-minimal/composer.json
+++ b/fixtures/typo3-extension-minimal/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "fixtures/typo3-extension-minimal",
+    "description": "Minimal TYPO3 extension shape for verifier regression tests.",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": "^8.2",
+        "typo3/cms-core": "^13.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "Fixtures\\Typo3ExtensionMinimal\\": "Classes/"
+        }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "typo3_extension_minimal"
+        }
+    }
+}

--- a/fixtures/typo3-extension-minimal/expected/verifier.json
+++ b/fixtures/typo3-extension-minimal/expected/verifier.json
@@ -1,0 +1,253 @@
+{
+  "agent_actions": [
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-01",
+      "confirm_required": false,
+      "operation": "create_phpstan_config",
+      "rationale": "PHPStan must be configured (phpstan.neon or phpstan.neon.dist)",
+      "target": "phpstan.neon"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-04",
+      "confirm_required": false,
+      "operation": "create_php_cs_fixer_config",
+      "rationale": "PHP-CS-Fixer must be configured to enforce coding standards",
+      "target": ".php-cs-fixer.dist.php"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-09",
+      "confirm_required": false,
+      "operation": "create_rector_config",
+      "rationale": "Rector enables automated refactoring for PHP version upgrades",
+      "target": "rector.php"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-13",
+      "confirm_required": false,
+      "operation": "add_cs_fix_script",
+      "rationale": "Coding-standards fix script makes the toolchain runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-14",
+      "confirm_required": false,
+      "operation": "add_phpstan_script",
+      "rationale": "PHPStan script makes static analysis runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-15",
+      "confirm_required": false,
+      "operation": "add_rector_script",
+      "rationale": "Rector script makes automated refactoring runnable via composer",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-16",
+      "confirm_required": false,
+      "operation": "require_dev_phpstan",
+      "rationale": "Add phpstan/phpstan to require-dev or rely on a transitive CI package",
+      "target": "composer.json"
+    },
+    {
+      "action": "edit_file",
+      "checkpoint": "PM-17",
+      "confirm_required": false,
+      "operation": "require_dev_php_cs_fixer",
+      "rationale": "Add friendsofphp/php-cs-fixer to require-dev or rely on a transitive CI package",
+      "target": "composer.json"
+    },
+    {
+      "action": "read_reference",
+      "checkpoint": "PM-25",
+      "confirm_required": false,
+      "operation": "introduce_phpat",
+      "rationale": "phpat enforces architectural rules in CI",
+      "target": "skills/php-modernization/references/static-analysis-tools.md"
+    }
+  ],
+  "archetype": "typo3-extension",
+  "checks": [
+    {
+      "category": "phpstan",
+      "evidence": [
+        "phpstan.neon",
+        "phpstan.neon.dist",
+        "Build/phpstan.neon",
+        "Build/phpstan/phpstan.neon"
+      ],
+      "id": "PM-01",
+      "message": "PHPStan configuration is missing",
+      "severity": "error",
+      "status": "fail"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-02",
+      "message": "PHPStan configuration not found; level cannot be evaluated",
+      "severity": "error",
+      "status": "skipped"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-03",
+      "message": "PHPStan configuration not found",
+      "severity": "warning",
+      "status": "skipped"
+    },
+    {
+      "category": "php-cs-fixer",
+      "evidence": [
+        ".php-cs-fixer.php",
+        ".php-cs-fixer.dist.php"
+      ],
+      "id": "PM-04",
+      "message": "PHP-CS-Fixer configuration is missing",
+      "severity": "error",
+      "status": "fail"
+    },
+    {
+      "category": "php-cs-fixer",
+      "evidence": [],
+      "id": "PM-05",
+      "message": "PHP-CS-Fixer configuration not found",
+      "severity": "error",
+      "status": "skipped"
+    },
+    {
+      "category": "rector",
+      "evidence": [
+        "rector.php",
+        "Build/rector.php",
+        "Build/rector/rector.php"
+      ],
+      "id": "PM-09",
+      "message": "Rector configuration is missing",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-13",
+      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix) found in composer.json",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-14",
+      "message": "No PHPStan script (phpstan/analyse/analyze) found in composer.json",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-15",
+      "message": "No Rector script (rector/refactor) found in composer.json",
+      "severity": "info",
+      "status": "fail"
+    },
+    {
+      "category": "dependencies",
+      "evidence": [],
+      "id": "PM-16",
+      "message": "PHPStan is not available \u2014 neither binary nor composer dependency detected",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "dependencies",
+      "evidence": [],
+      "id": "PM-17",
+      "message": "PHP-CS-Fixer is not available \u2014 neither binary nor composer dependency detected",
+      "severity": "warning",
+      "status": "fail"
+    },
+    {
+      "category": "composer",
+      "evidence": [
+        "composer.json"
+      ],
+      "id": "PM-19",
+      "message": "PSR-4 autoload defined (1 namespace mapping(s))",
+      "severity": "error",
+      "status": "pass"
+    },
+    {
+      "category": "architecture",
+      "evidence": [],
+      "id": "PM-25",
+      "message": "phpat is not configured \u2014 architecture tests recommended",
+      "severity": "info",
+      "status": "fail"
+    },
+    {
+      "category": "phpstan",
+      "evidence": [],
+      "id": "PM-53",
+      "message": "PHPStan configuration not found",
+      "severity": "warning",
+      "status": "skipped"
+    }
+  ],
+  "environment": {
+    "composer_json": true,
+    "composer_lock": false,
+    "php_runtime": "<NORMALIZED>",
+    "php_version_constraint": "^8.2"
+  },
+  "generated_at": "<NORMALIZED>",
+  "project_root": "<NORMALIZED>",
+  "schema_version": "1.0.0",
+  "skill": "php-modernization",
+  "skill_version": "1.16.0",
+  "summary": {
+    "errors": 2,
+    "info": 2,
+    "status": "fail",
+    "warnings": 5
+  },
+  "tool_runs": [],
+  "tooling": {
+    "composer_audit_supported": false,
+    "infection": {
+      "configured": false
+    },
+    "php_cs_fixer": {
+      "config_file": null,
+      "configured": false,
+      "ruleset_includes_per_cs": false
+    },
+    "phpat": {
+      "configured": false
+    },
+    "phpstan": {
+      "baseline": null,
+      "config_file": null,
+      "configured": false,
+      "level": null
+    },
+    "rector": {
+      "config_file": null,
+      "configured": false
+    }
+  }
+}

--- a/fixtures/typo3-extension-minimal/expected/verifier.json
+++ b/fixtures/typo3-extension-minimal/expected/verifier.json
@@ -218,7 +218,7 @@
   "project_root": "<NORMALIZED>",
   "schema_version": "1.0.0",
   "skill": "php-modernization",
-  "skill_version": "1.16.0",
+  "skill_version": "1.17.0",
   "summary": {
     "errors": 2,
     "info": 2,

--- a/fixtures/typo3-extension-minimal/ext_emconf.php
+++ b/fixtures/typo3-extension-minimal/ext_emconf.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Fixture: TYPO3 Extension Minimal',
+    'description' => 'Synthetic TYPO3 extension fixture for verifier regression tests.',
+    'category' => 'plugin',
+    'state' => 'stable',
+    'version' => '0.0.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0-13.99.99',
+        ],
+    ],
+];

--- a/scripts/test_fixtures.py
+++ b/scripts/test_fixtures.py
@@ -229,6 +229,40 @@ def select_fixtures(name: str | None) -> list[Path]:
     return matched
 
 
+def _run_update(fixtures: list[Path]) -> int:
+    for fixture in fixtures:
+        update_snapshot(fixture)
+        sys.stdout.write(f"{fixture.relative_to(REPO_ROOT)}\tUPDATED\n")
+    return 0
+
+
+def _print_failure(rel: Path, diff: list[str], name_width: int) -> None:
+    sys.stdout.write(f"{str(rel).ljust(name_width)} FAIL\n")
+    for line in diff:
+        sys.stdout.write("  " + line)
+    if diff and not diff[-1].endswith("\n"):
+        sys.stdout.write("\n")
+
+
+def _run_check(fixtures: list[Path]) -> int:
+    name_width = max(40, max(len(str(f.relative_to(REPO_ROOT))) for f in fixtures))
+    passed = 0
+    failed_count = 0
+
+    for fixture in fixtures:
+        rel = fixture.relative_to(REPO_ROOT)
+        ok, diff = check_fixture(fixture)
+        if ok:
+            sys.stdout.write(f"{str(rel).ljust(name_width)} PASS\n")
+            passed += 1
+        else:
+            _print_failure(rel, diff, name_width)
+            failed_count += 1
+
+    sys.stdout.write(f"\n{passed}/{len(fixtures)} fixtures pass.\n")
+    return 0 if failed_count == 0 else 1
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(list(argv if argv is not None else sys.argv[1:]))
 
@@ -241,36 +275,7 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write("no fixtures discovered under fixtures/\n")
         return 2
 
-    if args.update:
-        for fixture in fixtures:
-            update_snapshot(fixture)
-            rel = fixture.relative_to(REPO_ROOT)
-            sys.stdout.write(f"{rel}\tUPDATED\n")
-        return 0
-
-    name_width = max(len(str(f.relative_to(REPO_ROOT))) for f in fixtures)
-    name_width = max(name_width, 40)
-    failed: list[tuple[Path, list[str]]] = []
-    passed_count = 0
-
-    for fixture in fixtures:
-        rel = fixture.relative_to(REPO_ROOT)
-        ok, diff = check_fixture(fixture)
-        if ok:
-            sys.stdout.write(f"{str(rel).ljust(name_width)} PASS\n")
-            passed_count += 1
-        else:
-            sys.stdout.write(f"{str(rel).ljust(name_width)} FAIL\n")
-            for line in diff:
-                sys.stdout.write("  " + line)
-            if diff and not diff[-1].endswith("\n"):
-                sys.stdout.write("\n")
-            failed.append((fixture, diff))
-
-    sys.stdout.write("\n")
-    total = len(fixtures)
-    sys.stdout.write(f"{passed_count}/{total} fixtures pass.\n")
-    return 0 if not failed else 1
+    return _run_update(fixtures) if args.update else _run_check(fixtures)
 
 
 if __name__ == "__main__":

--- a/scripts/test_fixtures.py
+++ b/scripts/test_fixtures.py
@@ -34,7 +34,9 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURES_DIR = REPO_ROOT / "fixtures"
-VERIFIER = REPO_ROOT / "skills" / "php-modernization" / "scripts" / "verify_php_project.py"
+VERIFIER = (
+    REPO_ROOT / "skills" / "php-modernization" / "scripts" / "verify_php_project.py"
+)
 NORMALIZED = "<NORMALIZED>"
 
 # Fields whose values vary per run/host. Replaced with NORMALIZED placeholder.
@@ -42,9 +44,7 @@ TOP_LEVEL_VOLATILE_FIELDS: tuple[str, ...] = (
     "generated_at",
     "project_root",
 )
-ENVIRONMENT_VOLATILE_FIELDS: tuple[str, ...] = (
-    "php_runtime",
-)
+ENVIRONMENT_VOLATILE_FIELDS: tuple[str, ...] = ("php_runtime",)
 
 
 def discover_fixtures() -> list[Path]:
@@ -217,9 +217,7 @@ def select_fixtures(name: str | None) -> list[Path]:
     matched = [f for f in all_fixtures if f.name == name]
     if not matched:
         available = ", ".join(f.name for f in all_fixtures) or "(none)"
-        sys.stderr.write(
-            f"no fixture named {name!r} (available: {available})\n"
-        )
+        sys.stderr.write(f"no fixture named {name!r} (available: {available})\n")
         raise SystemExit(2)
     return matched
 

--- a/scripts/test_fixtures.py
+++ b/scripts/test_fixtures.py
@@ -179,7 +179,14 @@ def check_fixture(fixture: Path) -> tuple[bool, list[str]]:
             "  run with --update to generate it\n",
         ]
     actual = normalize(run_verifier(fixture))
-    expected_raw = json.loads(target.read_text(encoding="utf-8"))
+    try:
+        expected_raw = json.loads(target.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return False, [
+            f"snapshot is not valid JSON: {target.relative_to(REPO_ROOT)}\n",
+            f"  {exc.__class__.__name__}: {exc}\n",
+            "  run with --update to regenerate it\n",
+        ]
     expected = normalize(expected_raw)  # idempotent — protects hand-edits
     actual_text = serialize(actual)
     expected_text = serialize(expected)

--- a/scripts/test_fixtures.py
+++ b/scripts/test_fixtures.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Regression-test runner for verifier output against synthetic project fixtures.
+
+Runs ``skills/php-modernization/scripts/verify_php_project.py`` against each
+fixture under ``fixtures/`` with deterministic flags (``--no-tools --no-cache``),
+applies a normalization pass to scrub fields that vary per environment, and
+diffs the result against ``<fixture>/expected/verifier.json``.
+
+Use ``--update`` to regenerate the golden snapshots when verifier output
+legitimately changes (e.g. a new check is added or skill_version bumps).
+
+Designed to be invoked via uv:
+
+    uv run scripts/test_fixtures.py
+    uv run scripts/test_fixtures.py --update
+    uv run scripts/test_fixtures.py --fixture generic-composer-minimal
+
+Stdlib only. Exits 0 if all fixtures pass, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_DIR = REPO_ROOT / "fixtures"
+VERIFIER = REPO_ROOT / "skills" / "php-modernization" / "scripts" / "verify_php_project.py"
+NORMALIZED = "<NORMALIZED>"
+
+# Fields whose values vary per run/host. Replaced with NORMALIZED placeholder.
+TOP_LEVEL_VOLATILE_FIELDS: tuple[str, ...] = (
+    "generated_at",
+    "project_root",
+)
+ENVIRONMENT_VOLATILE_FIELDS: tuple[str, ...] = (
+    "php_runtime",
+)
+
+
+def discover_fixtures() -> list[Path]:
+    """Return all fixture directories (those containing a composer.json)."""
+    if not FIXTURES_DIR.is_dir():
+        return []
+    out: list[Path] = []
+    for child in sorted(FIXTURES_DIR.iterdir()):
+        if not child.is_dir():
+            continue
+        if (child / "composer.json").is_file():
+            out.append(child)
+    return out
+
+
+def run_verifier(fixture: Path) -> dict[str, Any]:
+    """Invoke the verifier on a fixture and return the parsed JSON output."""
+    cmd = [
+        "uv",
+        "run",
+        str(VERIFIER),
+        "--root",
+        str(fixture),
+        "--format",
+        "json",
+        "--no-tools",
+        "--no-cache",
+    ]
+    completed = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+    # Verifier exit codes: 0 pass/warn, 1 fail. Both produce valid JSON. Other
+    # codes (2 = bad args) are harness errors and should propagate.
+    if completed.returncode not in (0, 1):
+        sys.stderr.write(
+            f"verifier failed for {fixture.name}: exit {completed.returncode}\n"
+            f"stderr: {completed.stderr}\n"
+        )
+        raise SystemExit(2)
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(
+            f"verifier emitted invalid JSON for {fixture.name}: {exc}\n"
+            f"stdout: {completed.stdout[:500]}\n"
+        )
+        raise SystemExit(2) from exc
+
+
+def normalize(report: dict[str, Any]) -> dict[str, Any]:
+    """Scrub volatile fields and impose a stable ordering on collections.
+
+    Idempotent: applying twice yields the same result.
+    """
+    out: dict[str, Any] = dict(report)
+
+    # Scrub top-level volatile fields.
+    for key in TOP_LEVEL_VOLATILE_FIELDS:
+        if key in out:
+            out[key] = NORMALIZED
+
+    # Scrub environment.php_runtime (varies per CI runner / local install).
+    env = out.get("environment")
+    if isinstance(env, dict):
+        env = dict(env)
+        for key in ENVIRONMENT_VOLATILE_FIELDS:
+            if key in env:
+                env[key] = NORMALIZED
+        out["environment"] = env
+
+    # tool_runs[] is non-deterministic (subprocess data, paths, exit codes).
+    # The fixtures run with --no-tools so this should already be empty, but we
+    # drop it for safety in case a future verifier emits something here.
+    out["tool_runs"] = []
+
+    # Stable ordering for the collections an agent might re-emit in any order.
+    checks = out.get("checks")
+    if isinstance(checks, list):
+        out["checks"] = sorted(
+            checks, key=lambda c: c.get("id", "") if isinstance(c, dict) else ""
+        )
+    actions = out.get("agent_actions")
+    if isinstance(actions, list):
+        out["agent_actions"] = sorted(
+            actions,
+            key=lambda a: a.get("checkpoint", "") if isinstance(a, dict) else "",
+        )
+
+    return out
+
+
+def serialize(d: dict[str, Any]) -> str:
+    """Stable, pretty-printed JSON for diffing."""
+    return json.dumps(d, sort_keys=True, indent=2) + "\n"
+
+
+def diff_text(expected: str, actual: str, expected_label: str) -> list[str]:
+    return list(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            actual.splitlines(keepends=True),
+            fromfile=expected_label,
+            tofile="actual",
+            n=3,
+        )
+    )
+
+
+def expected_path(fixture: Path) -> Path:
+    return fixture / "expected" / "verifier.json"
+
+
+def update_snapshot(fixture: Path) -> None:
+    actual = run_verifier(fixture)
+    normalized = normalize(actual)
+    target = expected_path(fixture)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(serialize(normalized), encoding="utf-8")
+
+
+def check_fixture(fixture: Path) -> tuple[bool, list[str]]:
+    """Return (passed, diff_lines)."""
+    target = expected_path(fixture)
+    if not target.is_file():
+        return False, [
+            f"missing snapshot: {target.relative_to(REPO_ROOT)}\n",
+            "  run with --update to generate it\n",
+        ]
+    actual = normalize(run_verifier(fixture))
+    expected_raw = json.loads(target.read_text(encoding="utf-8"))
+    expected = normalize(expected_raw)  # idempotent — protects hand-edits
+    actual_text = serialize(actual)
+    expected_text = serialize(expected)
+    if actual_text == expected_text:
+        return True, []
+    return False, diff_text(
+        expected_text,
+        actual_text,
+        str(target.relative_to(REPO_ROOT)),
+    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="test_fixtures",
+        description="Verifier regression tests against fixture snapshots.",
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Regenerate fixture snapshots instead of diffing.",
+    )
+    parser.add_argument(
+        "--fixture",
+        metavar="NAME",
+        help="Run only the fixture with this directory name.",
+    )
+    return parser.parse_args(argv)
+
+
+def select_fixtures(name: str | None) -> list[Path]:
+    all_fixtures = discover_fixtures()
+    if name is None:
+        return all_fixtures
+    matched = [f for f in all_fixtures if f.name == name]
+    if not matched:
+        available = ", ".join(f.name for f in all_fixtures) or "(none)"
+        sys.stderr.write(
+            f"no fixture named {name!r} (available: {available})\n"
+        )
+        raise SystemExit(2)
+    return matched
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(list(argv if argv is not None else sys.argv[1:]))
+
+    if not VERIFIER.is_file():
+        sys.stderr.write(f"verifier not found at {VERIFIER}\n")
+        return 2
+
+    fixtures = select_fixtures(args.fixture)
+    if not fixtures:
+        sys.stderr.write("no fixtures discovered under fixtures/\n")
+        return 2
+
+    if args.update:
+        for fixture in fixtures:
+            update_snapshot(fixture)
+            rel = fixture.relative_to(REPO_ROOT)
+            sys.stdout.write(f"{rel}\tUPDATED\n")
+        return 0
+
+    name_width = max(len(str(f.relative_to(REPO_ROOT))) for f in fixtures)
+    name_width = max(name_width, 40)
+    failed: list[tuple[Path, list[str]]] = []
+    passed_count = 0
+
+    for fixture in fixtures:
+        rel = fixture.relative_to(REPO_ROOT)
+        ok, diff = check_fixture(fixture)
+        if ok:
+            sys.stdout.write(f"{str(rel).ljust(name_width)} PASS\n")
+            passed_count += 1
+        else:
+            sys.stdout.write(f"{str(rel).ljust(name_width)} FAIL\n")
+            for line in diff:
+                sys.stdout.write("  " + line)
+            if diff and not diff[-1].endswith("\n"):
+                sys.stdout.write("\n")
+            failed.append((fixture, diff))
+
+    sys.stdout.write("\n")
+    total = len(fixtures)
+    sys.stdout.write(f"{passed_count}/{total} fixtures pass.\n")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+# SonarCloud configuration for netresearch/php-modernization-skill
+sonar.projectKey=netresearch_php-modernization-skill
+sonar.organization=netresearch
+
+# Exclude synthetic test fixtures from analysis. Fixtures are minimal
+# composer.json files and PHP files used to drive the verifier regression
+# test suite — they intentionally lack lock files, real dependencies, and
+# production-grade quality. Treating them as production code generates
+# false-positive vulnerabilities (e.g., S8567 "missing composer.lock").
+sonar.exclusions=fixtures/**
+
+# Source roots
+sonar.sources=skills,scripts,schemas,.github
+sonar.tests=


### PR DESCRIPTION
## Summary

Adds 5 synthetic project fixtures and a snapshot-diff test runner. Lets us catch verifier-output regressions without depending on external repos like timetracker.

## Fixtures

Each minimal but archetype-detectable, with \`composer.json\` + the markers the verifier looks for + \`expected/verifier.json\` (the golden snapshot).

| Fixture | Archetype | What it tests |
|---|---|---|
| \`generic-composer-minimal\` | \`generic-composer\` | \`src/\`+\`tests/\` layout |
| \`symfony-app-minimal\` | \`symfony-app\` | \`bin/console\` + \`config/bundles.php\` markers |
| \`typo3-extension-minimal\` | \`typo3-extension\` | \`ext_emconf.php\` + \`Configuration/Services.yaml\` markers |
| \`monorepo-minimal\` | \`monorepo-package\` | \`packages/\` with multiple subpackages |
| \`fully-modern\` | \`generic-composer\` | **Positive control** — phpstan max + \`@PER-CS\` + rector + composer scripts. All 14 mechanical checks pass. |

## Test runner (\`scripts/test_fixtures.py\`)

- PEP 723, uv-runnable, stdlib only
- **Snapshot determinism**: replaces volatile fields (\`generated_at\`, \`project_root\`, \`environment.php_runtime\`) with \`<NORMALIZED>\` sentinels; drops \`tool_runs[]\`; sorts \`checks[]\` by id and \`agent_actions[]\` by checkpoint
- Normalization is **idempotent** — applied to both expected and actual
- CLI: default = run all, \`--update\` = regenerate snapshots, \`--fixture <name>\` = single fixture

## Verification

- 5/5 fixtures **PASS** in 0.33s
- Mutation-tested by breaking a snapshot — runner produces correct unified diff and exit 1
- \`uvx ruff check scripts/\` clean

## CI integration

\`.github/workflows/fixtures-test.yml\` runs the suite on every PR and push to main. Hardened with \`astral-sh/setup-uv@v6\` (no \`curl | sh\`), uploads diffs as artifact on failure.

## Why no version bump

This is internal regression infrastructure, not user-facing skill content. \`SKILL.md\` and \`plugin.json\` untouched.

## Test plan

- [x] All 5 fixtures pass against current main verifier
- [x] Mutation test confirms diff output and exit code semantics
- [x] Test runner completes in <30s
- [ ] CI green
- [ ] Copilot review resolved