### PR TITLE
fix(verifier): three calibration bugs surfaced by empirical validation

### DIFF
--- a/fixtures/composer-with-ci-naming/composer.json
+++ b/fixtures/composer-with-ci-naming/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "fixtures/composer-with-ci-naming",
+    "description": "Plain Composer library using Netresearch ci:cgl / ci:test:php:* script naming (regression coverage for verifier bug #2 + bug #3 generic-composer fallback without tests/).",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Fixtures\\ComposerWithCiNaming\\": "src/"
+        }
+    },
+    "scripts": {
+        "ci:cgl": "vendor/bin/php-cs-fixer fix --diff",
+        "ci:test:php:cgl": "vendor/bin/php-cs-fixer fix --dry-run --diff",
+        "ci:test:php:phpstan": "vendor/bin/phpstan analyse --no-progress",
+        "ci:test:php:rector": "vendor/bin/rector process --dry-run"
+    }
+}

--- a/fixtures/composer-with-ci-naming/expected/verifier.json
+++ b/fixtures/composer-with-ci-naming/expected/verifier.json
@@ -25,46 +25,6 @@
       "target": "rector.php"
     },
     {
-      "action": "edit_file",
-      "checkpoint": "PM-13",
-      "confirm_required": false,
-      "operation": "add_cs_fix_script",
-      "rationale": "Coding-standards fix script makes the toolchain runnable via composer",
-      "target": "composer.json"
-    },
-    {
-      "action": "edit_file",
-      "checkpoint": "PM-14",
-      "confirm_required": false,
-      "operation": "add_phpstan_script",
-      "rationale": "PHPStan script makes static analysis runnable via composer",
-      "target": "composer.json"
-    },
-    {
-      "action": "edit_file",
-      "checkpoint": "PM-15",
-      "confirm_required": false,
-      "operation": "add_rector_script",
-      "rationale": "Rector script makes automated refactoring runnable via composer",
-      "target": "composer.json"
-    },
-    {
-      "action": "edit_file",
-      "checkpoint": "PM-16",
-      "confirm_required": false,
-      "operation": "require_dev_phpstan",
-      "rationale": "Add phpstan/phpstan to require-dev or rely on a transitive CI package",
-      "target": "composer.json"
-    },
-    {
-      "action": "edit_file",
-      "checkpoint": "PM-17",
-      "confirm_required": false,
-      "operation": "require_dev_php_cs_fixer",
-      "rationale": "Add friendsofphp/php-cs-fixer to require-dev or rely on a transitive CI package",
-      "target": "composer.json"
-    },
-    {
       "action": "read_reference",
       "checkpoint": "PM-25",
       "confirm_required": false,
@@ -73,7 +33,7 @@
       "target": "skills/php-modernization/references/static-analysis-tools.md"
     }
   ],
-  "archetype": "typo3-extension",
+  "archetype": "generic-composer",
   "checks": [
     {
       "category": "phpstan",
@@ -141,9 +101,9 @@
         "composer.json"
       ],
       "id": "PM-13",
-      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix/ci:cgl/cgl) found in composer.json",
+      "message": "composer script 'ci:cgl' is defined",
       "severity": "warning",
-      "status": "fail"
+      "status": "pass"
     },
     {
       "category": "composer",
@@ -151,9 +111,9 @@
         "composer.json"
       ],
       "id": "PM-14",
-      "message": "No PHPStan script (phpstan/analyse/analyze/ci:test:php:phpstan/test:phpstan) found in composer.json",
+      "message": "composer script 'ci:test:php:phpstan' is defined",
       "severity": "warning",
-      "status": "fail"
+      "status": "pass"
     },
     {
       "category": "composer",
@@ -161,25 +121,25 @@
         "composer.json"
       ],
       "id": "PM-15",
-      "message": "No Rector script (rector/refactor/ci:test:php:rector/test:rector) found in composer.json",
+      "message": "composer script 'ci:test:php:rector' is defined",
       "severity": "info",
-      "status": "fail"
+      "status": "pass"
     },
     {
       "category": "dependencies",
       "evidence": [],
       "id": "PM-16",
-      "message": "PHPStan is not available \u2014 neither binary nor composer dependency detected",
+      "message": "PHPStan is available (binary or composer dependency)",
       "severity": "warning",
-      "status": "fail"
+      "status": "pass"
     },
     {
       "category": "dependencies",
       "evidence": [],
       "id": "PM-17",
-      "message": "PHP-CS-Fixer is not available \u2014 neither binary nor composer dependency detected",
+      "message": "PHP-CS-Fixer is available (binary or composer dependency)",
       "severity": "warning",
-      "status": "fail"
+      "status": "pass"
     },
     {
       "category": "composer",
@@ -221,9 +181,9 @@
   "skill_version": "1.17.0",
   "summary": {
     "errors": 2,
-    "info": 2,
+    "info": 1,
     "status": "fail",
-    "warnings": 5
+    "warnings": 1
   },
   "tool_runs": [],
   "tooling": {

--- a/fixtures/composer-with-ci-naming/src/Foo.php
+++ b/fixtures/composer-with-ci-naming/src/Foo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\ComposerWithCiNaming;
+
+final class Foo
+{
+    public function bar(): string
+    {
+        return 'ok';
+    }
+}

--- a/fixtures/generic-composer-minimal/expected/verifier.json
+++ b/fixtures/generic-composer-minimal/expected/verifier.json
@@ -141,7 +141,7 @@
         "composer.json"
       ],
       "id": "PM-13",
-      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix) found in composer.json",
+      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix/ci:cgl/cgl) found in composer.json",
       "severity": "warning",
       "status": "fail"
     },
@@ -151,7 +151,7 @@
         "composer.json"
       ],
       "id": "PM-14",
-      "message": "No PHPStan script (phpstan/analyse/analyze) found in composer.json",
+      "message": "No PHPStan script (phpstan/analyse/analyze/ci:test:php:phpstan/test:phpstan) found in composer.json",
       "severity": "warning",
       "status": "fail"
     },
@@ -161,7 +161,7 @@
         "composer.json"
       ],
       "id": "PM-15",
-      "message": "No Rector script (rector/refactor) found in composer.json",
+      "message": "No Rector script (rector/refactor/ci:test:php:rector/test:rector) found in composer.json",
       "severity": "info",
       "status": "fail"
     },

--- a/fixtures/monorepo-minimal/expected/verifier.json
+++ b/fixtures/monorepo-minimal/expected/verifier.json
@@ -141,7 +141,7 @@
         "composer.json"
       ],
       "id": "PM-13",
-      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix) found in composer.json",
+      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix/ci:cgl/cgl) found in composer.json",
       "severity": "warning",
       "status": "fail"
     },
@@ -151,7 +151,7 @@
         "composer.json"
       ],
       "id": "PM-14",
-      "message": "No PHPStan script (phpstan/analyse/analyze) found in composer.json",
+      "message": "No PHPStan script (phpstan/analyse/analyze/ci:test:php:phpstan/test:phpstan) found in composer.json",
       "severity": "warning",
       "status": "fail"
     },
@@ -161,7 +161,7 @@
         "composer.json"
       ],
       "id": "PM-15",
-      "message": "No Rector script (rector/refactor) found in composer.json",
+      "message": "No Rector script (rector/refactor/ci:test:php:rector/test:rector) found in composer.json",
       "severity": "info",
       "status": "fail"
     },

--- a/fixtures/symfony-app-minimal/expected/verifier.json
+++ b/fixtures/symfony-app-minimal/expected/verifier.json
@@ -141,7 +141,7 @@
         "composer.json"
       ],
       "id": "PM-13",
-      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix) found in composer.json",
+      "message": "No coding-standards fix script (cs:fix/fix:cs/php:cs:fix/ci:cgl/cgl) found in composer.json",
       "severity": "warning",
       "status": "fail"
     },
@@ -151,7 +151,7 @@
         "composer.json"
       ],
       "id": "PM-14",
-      "message": "No PHPStan script (phpstan/analyse/analyze) found in composer.json",
+      "message": "No PHPStan script (phpstan/analyse/analyze/ci:test:php:phpstan/test:phpstan) found in composer.json",
       "severity": "warning",
       "status": "fail"
     },
@@ -161,7 +161,7 @@
         "composer.json"
       ],
       "id": "PM-15",
-      "message": "No Rector script (rector/refactor) found in composer.json",
+      "message": "No Rector script (rector/refactor/ci:test:php:rector/test:rector) found in composer.json",
       "severity": "info",
       "status": "fail"
     },

--- a/fixtures/symfony-with-shared-phpstan-config/bin/console
+++ b/fixtures/symfony-with-shared-phpstan-config/bin/console
@@ -1,0 +1,7 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+// Symfony console marker file (fixture shape only — not executable).
+exit(0);

--- a/fixtures/symfony-with-shared-phpstan-config/composer.json
+++ b/fixtures/symfony-with-shared-phpstan-config/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "fixtures/symfony-with-shared-phpstan-config",
+    "description": "Symfony fixture whose phpstan.neon resolves level via shared includes (regression coverage for verifier bug #1).",
+    "type": "project",
+    "license": "MIT",
+    "require": {
+        "php": "^8.2",
+        "symfony/framework-bundle": "^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}

--- a/fixtures/symfony-with-shared-phpstan-config/config/bundles.php
+++ b/fixtures/symfony-with-shared-phpstan-config/config/bundles.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+];

--- a/fixtures/symfony-with-shared-phpstan-config/expected/verifier.json
+++ b/fixtures/symfony-with-shared-phpstan-config/expected/verifier.json
@@ -2,10 +2,10 @@
   "agent_actions": [
     {
       "action": "edit_file",
-      "checkpoint": "PM-01",
+      "checkpoint": "PM-03",
       "confirm_required": false,
-      "operation": "create_phpstan_config",
-      "rationale": "PHPStan must be configured (phpstan.neon or phpstan.neon.dist)",
+      "operation": "set_treat_phpdoc_types_as_certain_false",
+      "rationale": "treatPhpDocTypesAsCertain: false ensures PHPStan does not trust PHPDoc over runtime",
       "target": "phpstan.neon"
     },
     {
@@ -50,14 +50,6 @@
     },
     {
       "action": "edit_file",
-      "checkpoint": "PM-16",
-      "confirm_required": false,
-      "operation": "require_dev_phpstan",
-      "rationale": "Add phpstan/phpstan to require-dev or rely on a transitive CI package",
-      "target": "composer.json"
-    },
-    {
-      "action": "edit_file",
       "checkpoint": "PM-17",
       "confirm_required": false,
       "operation": "require_dev_php_cs_fixer",
@@ -73,36 +65,37 @@
       "target": "skills/php-modernization/references/static-analysis-tools.md"
     }
   ],
-  "archetype": "typo3-extension",
+  "archetype": "symfony-app",
   "checks": [
     {
       "category": "phpstan",
       "evidence": [
-        "phpstan.neon",
-        "phpstan.neon.dist",
-        "Build/phpstan.neon",
-        "Build/phpstan/phpstan.neon"
+        "phpstan.neon"
       ],
       "id": "PM-01",
-      "message": "PHPStan configuration is missing",
+      "message": "PHPStan configuration found at phpstan.neon",
       "severity": "error",
-      "status": "fail"
+      "status": "pass"
     },
     {
       "category": "phpstan",
-      "evidence": [],
+      "evidence": [
+        "phpstan.neon"
+      ],
       "id": "PM-02",
-      "message": "PHPStan configuration not found; level cannot be evaluated",
+      "message": "PHPStan level is 'max' (>= 9 / max)",
       "severity": "error",
-      "status": "skipped"
+      "status": "pass"
     },
     {
       "category": "phpstan",
-      "evidence": [],
+      "evidence": [
+        "phpstan.neon"
+      ],
       "id": "PM-03",
-      "message": "PHPStan configuration not found",
+      "message": "treatPhpDocTypesAsCertain: false is missing \u2014 PHPDoc types are trusted over runtime",
       "severity": "warning",
-      "status": "skipped"
+      "status": "fail"
     },
     {
       "category": "php-cs-fixer",
@@ -169,9 +162,9 @@
       "category": "dependencies",
       "evidence": [],
       "id": "PM-16",
-      "message": "PHPStan is not available \u2014 neither binary nor composer dependency detected",
+      "message": "PHPStan is available (binary or composer dependency)",
       "severity": "warning",
-      "status": "fail"
+      "status": "pass"
     },
     {
       "category": "dependencies",
@@ -201,11 +194,13 @@
     },
     {
       "category": "phpstan",
-      "evidence": [],
+      "evidence": [
+        "phpstan.neon"
+      ],
       "id": "PM-53",
-      "message": "PHPStan configuration not found",
+      "message": "PHPStan level is 'max' (max)",
       "severity": "warning",
-      "status": "skipped"
+      "status": "pass"
     }
   ],
   "environment": {
@@ -220,7 +215,7 @@
   "skill": "php-modernization",
   "skill_version": "1.17.0",
   "summary": {
-    "errors": 2,
+    "errors": 1,
     "info": 2,
     "status": "fail",
     "warnings": 5
@@ -241,9 +236,9 @@
     },
     "phpstan": {
       "baseline": null,
-      "config_file": null,
-      "configured": false,
-      "level": null
+      "config_file": "phpstan.neon",
+      "configured": true,
+      "level": "max"
     },
     "rector": {
       "config_file": null,

--- a/fixtures/symfony-with-shared-phpstan-config/phpstan.neon
+++ b/fixtures/symfony-with-shared-phpstan-config/phpstan.neon
@@ -1,0 +1,6 @@
+includes:
+    - shared/level.neon
+
+parameters:
+    paths:
+        - src

--- a/fixtures/symfony-with-shared-phpstan-config/shared/level.neon
+++ b/fixtures/symfony-with-shared-phpstan-config/shared/level.neon
@@ -1,0 +1,3 @@
+parameters:
+    level: max
+    treatPhpDocTypesAsCertain: false

--- a/fixtures/symfony-with-shared-phpstan-config/src/Controller/Foo.php
+++ b/fixtures/symfony-with-shared-phpstan-config/src/Controller/Foo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+final class Foo
+{
+    public function index(): string
+    {
+        return 'ok';
+    }
+}

--- a/skills/php-modernization/scripts/_common.py
+++ b/skills/php-modernization/scripts/_common.py
@@ -20,6 +20,13 @@ def detect_archetype(root: Path) -> str:
 
     Returns one of: typo3-extension, symfony-app, monorepo-package,
     generic-composer, unknown.
+
+    The ``generic-composer`` fallback recognises plain Composer libraries
+    that lack framework markers but still declare a PSR-4 autoload mapping
+    or carry a top-level ``src/`` directory. This matches typical SDK and
+    library shapes (e.g. ``netresearch/sdk-api-central-station``) where
+    requiring both ``src/`` and ``tests/`` would produce false ``unknown``
+    classifications.
     """
     if (root / "ext_emconf.php").is_file():
         return "typo3-extension"
@@ -38,12 +45,16 @@ def detect_archetype(root: Path) -> str:
         )
         if nested >= 2:
             return "monorepo-package"
-    if (
-        (root / "composer.json").is_file()
-        and (root / "src").is_dir()
-        and (root / "tests").is_dir()
-    ):
-        return "generic-composer"
+    if (root / "composer.json").is_file():
+        if (root / "src").is_dir():
+            return "generic-composer"
+        composer = read_composer_json(root)
+        if composer is not None:
+            autoload = composer.get("autoload") or {}
+            if isinstance(autoload, dict):
+                psr4 = autoload.get("psr-4")
+                if isinstance(psr4, dict) and psr4:
+                    return "generic-composer"
     return "unknown"
 
 

--- a/skills/php-modernization/scripts/verify_php_project.py
+++ b/skills/php-modernization/scripts/verify_php_project.py
@@ -250,8 +250,14 @@ def parse_phpstan_includes(text: str) -> list[str]:
         candidate = stripped[1:].strip()
         if not candidate or candidate.startswith("#"):
             continue
-        # Strip surrounding quotes if present (already handled by regex above,
-        # but keep idempotent so we can dedupe via the seen set).
+        # Strip trailing inline comment (NEON uses `#`). For unquoted paths,
+        # the comment is delimited by whitespace + `#`. Quoted paths preserve
+        # `#` as part of the value until the closing quote.
+        if not candidate.startswith(("'", '"')):
+            hash_match = re.search(r"\s+#", candidate)
+            if hash_match:
+                candidate = candidate[: hash_match.start()].rstrip()
+        # Strip surrounding quotes if present.
         if (candidate.startswith("'") and candidate.endswith("'")) or (
             candidate.startswith('"') and candidate.endswith('"')
         ):

--- a/skills/php-modernization/scripts/verify_php_project.py
+++ b/skills/php-modernization/scripts/verify_php_project.py
@@ -74,6 +74,25 @@ PHPSTAN_BASELINE_CANDIDATES: tuple[str, ...] = (
 
 PHPSTAN_LEVEL_RE = re.compile(r"^[\t ]*level:[\t ]*(?P<level>\S+)", re.MULTILINE)
 
+# NEON ``includes:`` block matcher — captures the YAML/NEON-style list that
+# follows the keyword, regardless of inline (``includes: ['a', 'b']``) or
+# indented dash form (``includes:\n    - a\n    - b``).
+PHPSTAN_INCLUDES_BLOCK_RE = re.compile(
+    r"^[\t ]*includes:[\t ]*(?P<rest>.*?)(?=^[\S]|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+PHPSTAN_INCLUDES_ITEM_RE = re.compile(
+    r"""
+    (?:^|[\s,\[])             # boundary: line start, whitespace, comma, or [
+    (?P<quote>['"])           # opening quote
+    (?P<path>[^'"\n]+)        # captured path
+    (?P=quote)                # matching closing quote
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+PHPSTAN_INCLUDE_DEPTH_LIMIT = 5
+
 SUBPROCESS_TIMEOUT_SECONDS = 300
 
 
@@ -198,6 +217,102 @@ def parse_phpstan_level(text: str) -> str | None:
     return m.group("level").strip()
 
 
+def parse_phpstan_includes(text: str) -> list[str]:
+    """Extract include paths from a phpstan.neon body.
+
+    Recognises both NEON forms:
+
+    - Inline list: ``includes: ['a.neon', "b.neon"]``
+    - Indented dash list:
+      ``includes:\\n    - a.neon\\n    - 'b.neon'``
+
+    Bare (unquoted) paths in the dash form are also matched.
+    """
+    block_match = PHPSTAN_INCLUDES_BLOCK_RE.search(text)
+    if not block_match:
+        return []
+    block = block_match.group("rest")
+    paths: list[str] = []
+    seen: set[str] = set()
+
+    # Quoted entries — works for both inline and indented forms.
+    for m in PHPSTAN_INCLUDES_ITEM_RE.finditer(block):
+        path = m.group("path").strip()
+        if path and path not in seen:
+            seen.add(path)
+            paths.append(path)
+
+    # Bare dash-list entries (NEON allows unquoted paths).
+    for line in block.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("-"):
+            continue
+        candidate = stripped[1:].strip()
+        if not candidate or candidate.startswith("#"):
+            continue
+        # Strip surrounding quotes if present (already handled by regex above,
+        # but keep idempotent so we can dedupe via the seen set).
+        if (candidate.startswith("'") and candidate.endswith("'")) or (
+            candidate.startswith('"') and candidate.endswith('"')
+        ):
+            candidate = candidate[1:-1]
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            paths.append(candidate)
+    return paths
+
+
+def resolve_phpstan_level(
+    config: Path,
+    *,
+    depth_limit: int = PHPSTAN_INCLUDE_DEPTH_LIMIT,
+) -> str | None:
+    """Resolve the effective PHPStan level by following ``includes:`` chain.
+
+    Local ``level:`` always wins (NEON include semantics: the including file
+    overrides included parameters). Only when the local file does not declare
+    a ``level:`` do we descend into ``includes:`` in declaration order and
+    return the first match found.
+
+    Cycle-safe via a visited-set keyed on resolved paths; bounded by
+    ``depth_limit`` (default 5) as a defensive guard.
+    """
+    visited: set[Path] = set()
+    return _resolve_phpstan_level_inner(config, visited, depth_limit)
+
+
+def _resolve_phpstan_level_inner(
+    config: Path, visited: set[Path], depth_remaining: int
+) -> str | None:
+    if depth_remaining < 0:
+        return None
+    try:
+        resolved = config.resolve()
+    except OSError:
+        return None
+    if resolved in visited:
+        return None
+    visited.add(resolved)
+    try:
+        body = config.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+    level = parse_phpstan_level(body)
+    if level is not None:
+        return level
+
+    base_dir = config.parent
+    for rel in parse_phpstan_includes(body):
+        candidate = (base_dir / rel) if not Path(rel).is_absolute() else Path(rel)
+        if not candidate.is_file():
+            continue
+        nested = _resolve_phpstan_level_inner(candidate, visited, depth_remaining - 1)
+        if nested is not None:
+            return nested
+    return None
+
+
 def phpstan_level_meets_threshold(level_token: str | None) -> bool:
     if level_token is None:
         return False
@@ -219,6 +334,52 @@ def composer_has_script(
     for name in names:
         if name in scripts:
             return name
+    return None
+
+
+def _script_value_contains(value: Any, marker: str) -> bool:
+    """True when a composer script ``value`` references ``marker``.
+
+    Composer scripts may be strings or lists of strings (sequential commands).
+    ``marker`` should be specific enough to identify the underlying tool
+    invocation (e.g. ``php-cs-fixer fix``, ``phpstan analyse``,
+    ``rector process``) so as not to collide with check-only scripts.
+    """
+    if isinstance(value, str):
+        return marker in value
+    if isinstance(value, list):
+        return any(_script_value_contains(item, marker) for item in value)
+    return False
+
+
+def composer_script_matches(
+    composer: dict[str, Any] | None,
+    *,
+    names: Iterable[str],
+    value_markers: Iterable[str] = (),
+) -> str | None:
+    """Locate a composer script by name equality or value substring.
+
+    Name matches take precedence (cheaper, unambiguous). Value markers are
+    matched against script bodies (string or list-of-strings) so projects
+    that wrap a tool under a non-standard script name (e.g. Netresearch's
+    ``ci:cgl`` running ``vendor/bin/php-cs-fixer fix``) are still
+    recognised.
+    """
+    if not composer:
+        return None
+    scripts = composer.get("scripts") or {}
+    if not isinstance(scripts, dict):
+        return None
+    for name in names:
+        if name in scripts:
+            return name
+    markers = tuple(value_markers)
+    if markers:
+        for name, value in scripts.items():
+            for marker in markers:
+                if _script_value_contains(value, marker):
+                    return name
     return None
 
 
@@ -306,11 +467,10 @@ def check_pm02(root: Path, config: Path | None) -> tuple[Check, str | None]:
             ),
             None,
         )
-    try:
-        body = config.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        body = ""
-    level = parse_phpstan_level(body)
+    # Resolve recursively through ``includes:`` chains so projects whose
+    # local phpstan.neon only includes a shared CI config still report the
+    # effective level (e.g. netresearch/typo3-ci-workflows ships ``level: max``).
+    level = resolve_phpstan_level(config)
     if phpstan_level_meets_threshold(level):
         return (
             Check(
@@ -447,7 +607,14 @@ def check_pm09(root: Path) -> tuple[Check, Path | None]:
 
 
 def check_pm13(composer: dict[str, Any] | None) -> Check:
-    found = composer_has_script(composer, ("cs:fix", "fix:cs", "php:cs:fix"))
+    # Names: PSR/de-facto + Netresearch ``ci:cgl`` / bare ``cgl`` convention.
+    # Value markers: ``php-cs-fixer fix`` is specific enough to avoid colliding
+    # with the dry-run check command (``php-cs-fixer check`` / ``--dry-run``).
+    found = composer_script_matches(
+        composer,
+        names=("cs:fix", "fix:cs", "php:cs:fix", "ci:cgl", "cgl"),
+        value_markers=("php-cs-fixer fix",),
+    )
     if found:
         return Check(
             id="PM-13",
@@ -462,13 +629,29 @@ def check_pm13(composer: dict[str, Any] | None) -> Check:
         category="composer",
         severity="warning",
         status="fail",
-        message="No coding-standards fix script (cs:fix/fix:cs/php:cs:fix) found in composer.json",
+        message=(
+            "No coding-standards fix script "
+            "(cs:fix/fix:cs/php:cs:fix/ci:cgl/cgl) found in composer.json"
+        ),
         evidence=["composer.json"],
     )
 
 
 def check_pm14(composer: dict[str, Any] | None) -> Check:
-    found = composer_has_script(composer, ("phpstan", "analyse", "analyze"))
+    # Names: PSR/de-facto + Netresearch CI naming.
+    # Value markers: tighten with the analyse subcommand to avoid matching
+    # mere mentions of the binary path.
+    found = composer_script_matches(
+        composer,
+        names=(
+            "phpstan",
+            "analyse",
+            "analyze",
+            "ci:test:php:phpstan",
+            "test:phpstan",
+        ),
+        value_markers=("phpstan analyse", "phpstan analyze"),
+    )
     if found:
         return Check(
             id="PM-14",
@@ -483,13 +666,21 @@ def check_pm14(composer: dict[str, Any] | None) -> Check:
         category="composer",
         severity="warning",
         status="fail",
-        message="No PHPStan script (phpstan/analyse/analyze) found in composer.json",
+        message=(
+            "No PHPStan script "
+            "(phpstan/analyse/analyze/ci:test:php:phpstan/test:phpstan) "
+            "found in composer.json"
+        ),
         evidence=["composer.json"],
     )
 
 
 def check_pm15(composer: dict[str, Any] | None) -> Check:
-    found = composer_has_script(composer, ("rector", "refactor"))
+    found = composer_script_matches(
+        composer,
+        names=("rector", "refactor", "ci:test:php:rector", "test:rector"),
+        value_markers=("rector process",),
+    )
     if found:
         return Check(
             id="PM-15",
@@ -504,7 +695,11 @@ def check_pm15(composer: dict[str, Any] | None) -> Check:
         category="composer",
         severity="info",
         status="fail",
-        message="No Rector script (rector/refactor) found in composer.json",
+        message=(
+            "No Rector script "
+            "(rector/refactor/ci:test:php:rector/test:rector) "
+            "found in composer.json"
+        ),
         evidence=["composer.json"],
     )
 

--- a/skills/php-modernization/scripts/verify_php_project.py
+++ b/skills/php-modernization/scripts/verify_php_project.py
@@ -78,15 +78,25 @@ PHPSTAN_LEVEL_RE = re.compile(r"^[\t ]*level:[\t ]*(?P<level>\S+)", re.MULTILINE
 # follows the keyword, regardless of inline (``includes: ['a', 'b']``) or
 # indented dash form (``includes:\n    - a\n    - b``).
 PHPSTAN_INCLUDES_BLOCK_RE = re.compile(
-    r"^[\t ]*includes:[\t ]*(?P<rest>.*?)(?=^[\S]|\Z)",
+    # Match the includes block. The block ends at the next top-level key
+    # (a non-whitespace identifier followed by ":"), NOT at the next
+    # non-whitespace character — that earlier rule incorrectly terminated on
+    # unindented dash-list items like `- shared/level.neon` which are valid
+    # NEON list members at any indent level.
+    r"^[\t ]*includes:[\t ]*(?P<rest>.*?)(?=^[A-Za-z_][\w.-]*\s*:|\Z)",
     re.MULTILINE | re.DOTALL,
 )
 PHPSTAN_INCLUDES_ITEM_RE = re.compile(
     r"""
     (?:^|[\s,\[])             # boundary: line start, whitespace, comma, or [
-    (?P<quote>['"])           # opening quote
-    (?P<path>[^'"\n]+)        # captured path
-    (?P=quote)                # matching closing quote
+    (?:
+        (?P<quote>['"])(?P<qpath>[^'"\n]+)(?P=quote)   # quoted path
+      |                                                # OR
+        (?P<bpath>[^\s,\[\]'"#][^\s,\[\]#]*)           # bare unquoted path
+                                                       # (no whitespace, comma,
+                                                       # bracket, quote or
+                                                       # hash anywhere)
+    )
     """,
     re.VERBOSE | re.MULTILINE,
 )
@@ -235,9 +245,9 @@ def parse_phpstan_includes(text: str) -> list[str]:
     paths: list[str] = []
     seen: set[str] = set()
 
-    # Quoted entries — works for both inline and indented forms.
+    # Quoted and bare entries from inline `[a, b]` form.
     for m in PHPSTAN_INCLUDES_ITEM_RE.finditer(block):
-        path = m.group("path").strip()
+        path = (m.group("qpath") or m.group("bpath") or "").strip()
         if path and path not in seen:
             seen.add(path)
             paths.append(path)
@@ -383,10 +393,50 @@ def composer_script_matches(
     markers = tuple(value_markers)
     if markers:
         for name, value in scripts.items():
+            # Skip Composer lifecycle events — they fire automatically and
+            # are not developer-callable "tool scripts" (PM-13/14/15 ask
+            # whether the project ships an explicit toolchain entry).
+            if name in COMPOSER_EVENT_SCRIPTS:
+                continue
             for marker in markers:
                 if _script_value_contains(value, marker):
                     return name
     return None
+
+
+# Composer reserved lifecycle/event script names (per the Composer schema).
+# https://getcomposer.org/doc/articles/scripts.md
+COMPOSER_EVENT_SCRIPTS: frozenset[str] = frozenset(
+    {
+        "pre-install-cmd",
+        "post-install-cmd",
+        "pre-update-cmd",
+        "post-update-cmd",
+        "pre-status-cmd",
+        "post-status-cmd",
+        "pre-archive-cmd",
+        "post-archive-cmd",
+        "pre-autoload-dump",
+        "post-autoload-dump",
+        "post-root-package-install",
+        "post-create-project-cmd",
+        "pre-dependencies-solving",
+        "post-dependencies-solving",
+        "pre-package-install",
+        "post-package-install",
+        "pre-package-update",
+        "post-package-update",
+        "pre-package-uninstall",
+        "post-package-uninstall",
+        "pre-pool-create",
+        "init",
+        "command",
+        "pre-file-download",
+        "post-file-download",
+        "pre-command-run",
+        "error",
+    }
+)
 
 
 def find_in_files(root: Path, files: Iterable[str], needle: str) -> Path | None:


### PR DESCRIPTION
Discovered during empirical validation of the skill against 4 real Netresearch codebases (`timetracker`, `sdk-api-central-station`, `t3x-nr-llm`, `t3x-rte_ckeditor_image`). Each bug below surfaced as a false positive on at least one of those projects.

## Bugs fixed

### #1 — PM-02 PHPStan level resolution through `includes:` chains

**Surfaced by**: `t3x-nr-llm`, `t3x-rte_ckeditor_image` (and any project whose `phpstan.neon` only `includes:` a shared CI config such as `vendor/netresearch/typo3-ci-workflows/config/phpstan/phpstan.neon`).

**Symptom**: PM-02 reported `level 'unset'` even though the resolved PHPStan run uses `level: max` from a shared file.

**Fix**: New `resolve_phpstan_level()` in `verify_php_project.py` walks `includes:` recursively (depth-capped at 5, cycle-safe via resolved-path set). Local `level:` always wins, matching NEON include semantics. Both NEON forms recognised — inline `includes: ['a.neon']` and indented dash list (`- a.neon`), quoted or bare. The resolved level threads through `check_pm02`, `check_pm53`, and `tooling.phpstan["level"]`.

### #2 — PM-13/14/15 recognise Netresearch composer-script naming

**Surfaced by**: every Netresearch project (all 4 codebases hit this).

**Symptom**: Hardcoded name list (`cs:fix`/`phpstan`/`rector`) missed the Netresearch standard (`ci:cgl`/`ci:test:php:phpstan`/`ci:test:php:rector`), reporting fail on projects that have those scripts.

**Fix**: New `composer_script_matches()` matches by name equality OR by specific value markers (`php-cs-fixer fix`, `phpstan analyse`, `rector process`) — markers are deliberately specific to avoid colliding with check-only scripts (e.g. `php-cs-fixer check`). Composer script *values* may be a string or a list of strings; both shapes handled. Extended name lists:

- PM-13: + `ci:cgl`, `cgl`
- PM-14: + `ci:test:php:phpstan`, `test:phpstan`
- PM-15: + `ci:test:php:rector`, `test:rector`

### #3 — `detect_archetype()` falls back to `generic-composer` for plain libraries

**Surfaced by**: `sdk-api-central-station`.

**Symptom**: Returned `unknown` whenever no framework markers were present, even for clearly-recognisable Composer libraries (`composer.json` + `src/` declared via PSR-4).

**Fix**: New step 4 in `_common.detect_archetype()` returns `generic-composer` when `composer.json` exists AND (`src/` is present OR `autoload.psr-4` declares any namespace). The previous `src/ AND tests/` requirement is dropped — many SDKs ship with `src/` only.

## New fixtures

- `fixtures/symfony-with-shared-phpstan-config/` — phpstan.neon uses indented dash form to include `shared/level.neon`; PM-02 must report `max`. Archetype: `symfony-app`.
- `fixtures/composer-with-ci-naming/` — Netresearch `ci:cgl` / `ci:test:php:phpstan` / `ci:test:php:rector` scripts; PM-13/14/15 must pass. Has `src/` only (no `tests/`) — exercises Bug #3 fallback. Archetype: `generic-composer`.

## Out of scope (deferred to follow-up issues)

- introspect / verifier inconsistency on Infection detection
- Missing stale-migration-preset check
- JSON output omitting passing checks
- Runtime vs constraint divergence not flagged

These will be tracked as separate issues, not addressed here, to keep this PR scoped to the calibration regression.

## Test plan

- [x] `uv run scripts/test_fixtures.py` — 7/7 fixtures pass (5 existing snapshots updated for the PM-13/14/15 message-text change; 2 new fixtures added)
- [x] `uvx ruff check scripts/ skills/` — clean
- [x] `uvx ruff format --check scripts/ skills/` — clean
- [ ] CI green
- [ ] Copilot review