### PR TITLE
docs: add PHPUnit 12→13 modernization + multi-agent pitfalls references

### DIFF
--- a/skills/php-modernization/SKILL.md
+++ b/skills/php-modernization/SKILL.md
@@ -57,7 +57,7 @@ Modernize PHP to 8.1-8.5, PSR/PER-CS, PHPStan max, type safety.
 ## Hard guardrails
 
 - Never apply `readonly` to Doctrine entities or mapped-superclasses (embeddables: see `references/doctrine-modernization-edges.md`).
-- Never run Rector without `--dry-run`. Invoke `vendor/bin/rector` directly — `composer rector -- --dry-run` swallows the flag.
+- Never run Rector without `--dry-run`. Invoke `vendor/bin/rector` directly — composer script aliases can drop `--`-forwarded flags depending on configuration.
 - Never raise PHPStan level without regenerating + committing the baseline. Shrink, never delete.
 - Never apply blanket `final` to mock targets or extension points without confirmation.
 - Never edit `@generated` files or files under `var/cache/`, `vendor/`, `node_modules/`, `.Build/`.

--- a/skills/php-modernization/SKILL.md
+++ b/skills/php-modernization/SKILL.md
@@ -21,64 +21,61 @@ allowed-tools:
 
 # PHP Modernization
 
-Modernize PHP to current standards: PHP 8.1-8.5, PSR/PHP-FIG, PER-CS, PHPStan max, type safety.
+Modernize PHP to 8.1-8.5, PSR/PER-CS, PHPStan max, type safety.
 
 ## Agent contract
 
-1. **Discover**: `uv run scripts/introspect.py` (cheap), or `uv run scripts/verify_php_project.py --summary` (full, with `agent_actions[]`).
-2. **Drill**: `... --check PM-XX` for one finding. Full output only when triaging >3.
-3. **Apply**: `uv run scripts/modernize_loop.py --mode dry-run` — review transcript before applying.
-4. **References**: load on demand from the table; do not pre-load.
+1. **Discover**: `uv run ${CLAUDE_SKILL_DIR}/scripts/introspect.py` (cheap), or `verify_php_project.py --summary` (full, with `agent_actions[]`).
+2. **Drill**: `... --check PM-XX` per finding. Full output when triaging >3.
+3. **Apply**: `uv run ${CLAUDE_SKILL_DIR}/scripts/modernize_loop.py --mode dry-run`. Review transcript before applying.
+4. **References**: load on demand; do not pre-load.
 
 ## Reference routing
 
 | Need | Read |
 |---|---|
 | PHP 8.0-8.3 baseline | `references/php8-features.md` |
-| PHP 8.4 (hooks, asymmetric visibility, lazy objects) | `references/php-8.4.md` |
-| PHP 8.5 (pipe, array_first/last, `#[\NoDiscard]`) | `references/php-8.5.md` |
+| PHP 8.4 | `references/php-8.4.md` |
+| PHP 8.5 | `references/php-8.5.md` |
 | PSR / PER-CS | `references/psr-per-compliance.md` |
 | PHPStan config | `references/phpstan-compliance.md` |
-| Static analysis overview | `references/static-analysis-tools.md` |
+| Static analysis | `references/static-analysis-tools.md` |
 | PHP-CS-Fixer deprecations | `references/php-cs-fixer-deprecations.md` |
-| DTOs / VOs / typed inputs | `references/type-safety.md`, `references/request-dtos.md` |
+| DTOs / VOs / inputs | `references/type-safety.md`, `references/request-dtos.md` |
 | Adapter / registry | `references/adapter-registry-pattern.md` |
 | Multi-version compat | `references/multi-version-adapters.md` |
-| Symfony as PSR exemplar | `references/symfony-patterns.md` |
-| PSR-15 middleware architecture | `references/psr15-middleware-architecture.md` |
+| Symfony patterns | `references/symfony-patterns.md` |
+| PSR-15 middleware | `references/psr15-middleware-architecture.md` |
 | Doctrine edges | `references/doctrine-modernization-edges.md` |
-| API Platform edges | `references/api-platform-edges.md` |
-| Immutability boundaries | `references/immutability-boundaries.md` |
+| API Platform | `references/api-platform-edges.md` |
+| Immutability | `references/immutability-boundaries.md` |
 | Mutation testing | `references/mutation-testing.md` |
 | Migration planning | `references/migration-strategies.md` |
+| PHPUnit 12→13, mock vs stub | `references/phpunit-modernization.md` |
+| Multi-agent dispatch hazards | `references/multi-agent-pitfalls.md` |
 
 ## Hard guardrails
 
-- Never apply `readonly` to Doctrine entities or mapped-superclasses (embeddables are a nuanced case, ORM 3.x dependent — see `references/doctrine-modernization-edges.md`).
-- Never run Rector without `--dry-run` first.
-- Never raise PHPStan level without regenerating + committing the baseline in the same change. Shrink, never delete.
+- Never apply `readonly` to Doctrine entities or mapped-superclasses (embeddables: see `references/doctrine-modernization-edges.md`).
+- Never run Rector without `--dry-run`. Invoke `vendor/bin/rector` directly — `composer rector -- --dry-run` swallows the flag.
+- Never raise PHPStan level without regenerating + committing the baseline. Shrink, never delete.
 - Never apply blanket `final` to mock targets or extension points without confirmation.
 - Never edit `@generated` files or files under `var/cache/`, `vendor/`, `node_modules/`, `.Build/`.
-
-## Tooling baseline
-
-PHPStan ≥9 (10 recommended). PHP-CS-Fixer `@PER-CS`. Rector with version-set matching project PHP. PHPat where layer boundaries exist. `composer audit` on every run. Infection in PR-diff mode.
+- Never `git checkout --` files outside your scope in shared trees — use `git stash` / `git diff`.
+- Never trust a warm PHPStan cache after vendor change: `rm -rf /tmp/phpstan-* var/cache/phpstan` first.
+- Never mass-substitute `createMock` → `createStub` — promote to `expects(...)->method(...)->with(...)`.
 
 ## Migration checklist
 
 - [ ] `declare(strict_types=1)` everywhere
 - [ ] `@PER-CS`, no deprecated aliases
-- [ ] PHPStan ≥9 (`treatPhpDocTypesAsCertain: false`); 10 for new projects
+- [ ] PHPStan ≥9 (`treatPhpDocTypesAsCertain: false`); 10 for new
 - [ ] PHPat for layer boundaries
 - [ ] Return + parameter types on all methods
 - [ ] DTOs over arrays; backed enums over constants
 - [ ] PSR interfaces in type-hints
 - [ ] `#[Override]` (8.3+), `#[SensitiveParameter]` (8.2+), typed constants (8.3+)
-- [ ] readonly on DTOs/VOs/events only — see `references/immutability-boundaries.md`
-- [ ] Property hooks (8.4) for validated mutable state
-- [ ] `array_find` / `array_any` / `array_all` over manual loops (8.4)
-- [ ] Pipe `|>` for transform pipelines (8.5)
-
----
-
-> Source: https://github.com/netresearch/php-modernization-skill
+- [ ] readonly on DTOs/VOs/events only
+- [ ] Property hooks (8.4); `array_find/any/all` (8.4); pipe `|>` (8.5)
+- [ ] PHPUnit 12+: stubs use `createStub`, mocks `createMock` + `expects` (no `self::any()` in 13)
+- [ ] Rector `withComposerBased(symfony: true)` (per-version `SymfonySetList::SYMFONY_*` are `@deprecated`)

--- a/skills/php-modernization/references/multi-agent-pitfalls.md
+++ b/skills/php-modernization/references/multi-agent-pitfalls.md
@@ -37,24 +37,26 @@ vendor/bin/phpstan analyse --no-progress
 **Brief every agent**: when scripted commands accept flags, hand the
 agent the raw binary invocation, not the composer alias.
 
-## Hazard 2: Never `git checkout -- <file>` mid-multi-agent run
+## Hazard 2: `git checkout --` outside your declared scope
 
-If sub-agents are running in parallel against the same working tree,
-one agent's `git checkout -- <path>` can wipe out another agent's
-uncommitted edits.
+If sub-agents run in parallel against the same working tree, one
+agent's `git checkout -- <path>` on a file outside its declared scope
+can wipe out a sibling agent's uncommitted edits.
 
-**Safer alternatives** when an agent needs to test a "main" baseline:
+**The rule (single, unambiguous):**
+
+> An agent may only `git checkout --` / `git restore` files **inside
+> its own declared file scope**. For any file outside that scope —
+> including auto-generated files (Hazard 6) — use `git stash`,
+> `git diff`, or coordinate with the orchestrator instead.
+
+**Safer alternatives** when comparing to a baseline:
 
 - `git stash push -m "tmp"`, do the read-only test, `git stash pop`.
   Stashes are agent-private as long as the name is unique.
 - Spawn a separate read-only worktree with `isolation: "worktree"` for
   the discovery work. (Don't write across worktrees.)
-- Just `git diff main -- <path>` to see what's different without
-  reverting.
-
-**Brief every agent that touches state**: "Do not run `git checkout
---` or `git restore` on files outside your declared scope. If you need
-to compare against main, use `git stash` or `git diff` instead."
+- `git diff main -- <path>` to see differences without reverting.
 
 ## Hazard 3: Local PHPStan cache lies vs CI
 
@@ -71,10 +73,15 @@ which this routinely diverges from CI:
 **Mitigation in the agent's verification step**:
 
 ```bash
-rm -rf /tmp/phpstan-* var/cache/phpstan
-composer install                # if composer.lock changed since last run
+composer install                            # if composer.lock changed
+vendor/bin/phpstan clear-result-cache       # invalidate analysis cache safely
 vendor/bin/phpstan analyse --no-progress
 ```
+
+`vendor/bin/phpstan clear-result-cache` is the supported way to clear
+PHPStan's cache — it knows the actual `tmpDir` from the config, and
+won't accidentally nuke caches from sibling projects on the same
+machine the way `rm -rf /tmp/phpstan-*` could.
 
 Always run this **before** reporting `[OK] No errors`. The skill's
 default verify scripts should not declare success on a cached run.
@@ -111,14 +118,19 @@ regenerates `config/reference.php`. Doctrine migrations and schema
 files have similar regenerators. If the agent commits these, every
 subsequent `composer install` produces a fresh diff.
 
-**Mitigation**:
+**Mitigation** (in order of preference):
 
-- Agents should `git checkout -- <generated-file>` (yes, this hazard
-  collides with #2 — agents have to be precise) BEFORE staging final
-  commits.
-- The verify script should detect Symfony auto-generated files in the
-  staged diff and warn.
-- Better: project should gitignore them. Suggest this in the PR.
+1. **Best**: project gitignores the file. Suggest this in the PR.
+2. **Without gitignore**: at the END of the agent's work, after all
+   sibling agents have committed, run `git restore <generated-file>`
+   *only if that file is in YOUR declared scope* (per Hazard 2). The
+   orchestrator should give exactly one agent ownership of cleanup.
+3. **Mid-run**: don't restore. Commit your real edits, then submit a
+   follow-up commit that restores the regenerated file.
+4. **Alternative**: `git update-index --assume-unchanged <file>` for
+   the duration of the run — files don't appear in `git status` and
+   regenerators won't pollute the diff. Reset with `--no-assume-unchanged`
+   when done.
 
 ## Hazard 7: Pre-commit hooks running tests on the host
 
@@ -149,12 +161,13 @@ in parallel:
 
 ```
 SHARED REPO HAZARDS:
-- Use bin/rector / vendor/bin/php-cs-fixer / vendor/bin/phpstan
-  directly. Do NOT use `composer rector -- --dry-run` (composer
-  swallows the flag).
+- Use vendor/bin/rector / vendor/bin/php-cs-fixer / vendor/bin/phpstan
+  directly. Composer script aliases sometimes drop --forwarded flags
+  depending on the script body's quoting.
 - Do NOT run `git checkout --`, `git restore`, or `git reset --hard`
-  on any file. Use `git stash` for temporary baselines.
-- Before reporting clean: `rm -rf /tmp/phpstan-* var/cache/phpstan`
+  on files OUTSIDE your declared scope. Use `git stash` / `git diff`
+  to compare to a baseline.
+- Before reporting clean: `vendor/bin/phpstan clear-result-cache`
   and re-run analyse.
 - After any composer.lock change in your scope: run `composer install`.
 - If pre-commit hooks block your commit: report the hook output, do

--- a/skills/php-modernization/references/multi-agent-pitfalls.md
+++ b/skills/php-modernization/references/multi-agent-pitfalls.md
@@ -1,0 +1,162 @@
+# Multi-Agent Modernization Pitfalls
+
+Empirical hazards when dispatching parallel sub-agents for a PHP
+modernization pass. All of these were observed in production runs and
+are worth bracing against in the agent's instructions.
+
+## Hazard 1: `composer SCRIPT -- --flag` does NOT forward the flag
+
+Composer scripts have well-known argument-forwarding limitations. The
+canonical example:
+
+```jsonc
+"scripts": {
+    "rector": "rector process src --config=config/quality/rector.php"
+}
+```
+
+```bash
+# Looks like a dry-run. Actually runs rector in APPLY mode.
+composer rector -- --dry-run
+```
+
+**Why it bites in multi-agent runs**: a "config cleanup" sub-agent
+running this thinking it's safe will modify source files. If it
+notices and reverts via `git checkout -- <files>`, those files may have
+been modified by a sibling agent — its uncommitted work vanishes
+silently.
+
+**Workaround**: invoke the binary directly when you need the flag.
+
+```bash
+bin/rector process src --config=config/quality/rector.php --dry-run
+vendor/bin/php-cs-fixer fix --dry-run --diff
+vendor/bin/phpstan analyse --no-progress
+```
+
+**Brief every agent**: when scripted commands accept flags, hand the
+agent the raw binary invocation, not the composer alias.
+
+## Hazard 2: Never `git checkout -- <file>` mid-multi-agent run
+
+If sub-agents are running in parallel against the same working tree,
+one agent's `git checkout -- <path>` can wipe out another agent's
+uncommitted edits.
+
+**Safer alternatives** when an agent needs to test a "main" baseline:
+
+- `git stash push -m "tmp"`, do the read-only test, `git stash pop`.
+  Stashes are agent-private as long as the name is unique.
+- Spawn a separate read-only worktree with `isolation: "worktree"` for
+  the discovery work. (Don't write across worktrees.)
+- Just `git diff main -- <path>` to see what's different without
+  reverting.
+
+**Brief every agent that touches state**: "Do not run `git checkout
+--` or `git restore` on files outside your declared scope. If you need
+to compare against main, use `git stash` or `git diff` instead."
+
+## Hazard 3: Local PHPStan cache lies vs CI
+
+`phpstan.neon` typically configures `tmpDir: /tmp/phpstan-X`. The cache
+indexes analysis results keyed to vendor stubs. Two lab conditions in
+which this routinely diverges from CI:
+
+- After a rebase that bumped a `phpstan-*-bridge` extension or
+  PHPUnit major (CI builds vendor cleanly; local doesn't unless
+  `composer install` was re-run).
+- After mass test refactors where the local `tmpDir` already analysed
+  the OLD code shape.
+
+**Mitigation in the agent's verification step**:
+
+```bash
+rm -rf /tmp/phpstan-* var/cache/phpstan
+composer install                # if composer.lock changed since last run
+vendor/bin/phpstan analyse --no-progress
+```
+
+Always run this **before** reporting `[OK] No errors`. The skill's
+default verify scripts should not declare success on a cached run.
+
+## Hazard 4: Vendor skew after rebase
+
+If a rebase pulled in `composer.lock` updates (e.g. another PR
+upgraded a major version) and the agent doesn't run `composer install`,
+the local `vendor/` still has the old version. Tests may pass locally
+on the old binary while failing in CI on the new.
+
+**Brief**: any agent that rebases or merges into its working tree
+should run `composer install --ignore-platform-req=...` afterwards (or
+inside Docker if the host lacks the project's PHP extensions).
+
+## Hazard 5: File-scope overlap between concurrent agents
+
+If two agents have overlapping file scopes, the second to finish
+overwrites the first's edits. Even with no overlap on lines, edits
+made via Read+Edit on different lines of the same file race.
+
+**Allocate scopes by file, not by feature**. If two agents both need to
+touch `JiraHttpClientService.php`, sequence them — the second runs
+after the first commits.
+
+When a third agent must touch a file the previous two also touched,
+brief it with the post-merge state and the specific line ranges, and
+have it re-read the file before editing.
+
+## Hazard 6: Auto-generated files repeatedly re-appearing in the diff
+
+Symfony's `symfony-cmd`-driven `cache:clear` post-install hook
+regenerates `config/reference.php`. Doctrine migrations and schema
+files have similar regenerators. If the agent commits these, every
+subsequent `composer install` produces a fresh diff.
+
+**Mitigation**:
+
+- Agents should `git checkout -- <generated-file>` (yes, this hazard
+  collides with #2 — agents have to be precise) BEFORE staging final
+  commits.
+- The verify script should detect Symfony auto-generated files in the
+  staged diff and warn.
+- Better: project should gitignore them. Suggest this in the PR.
+
+## Hazard 7: Pre-commit hooks running tests on the host
+
+Many projects' `captainhook` / husky / pre-commit configs run
+`phpunit` directly on host PHP. If the host lacks the project's
+required extensions (`pdo_mysql`, `ldap`, etc.) or has stale-cache
+issues, the hook fails on every commit with environmental errors that
+have nothing to do with the staged changes.
+
+**Workarounds in priority order**:
+
+1. Ask the user to install the missing extension or configure the hook
+   to run via `docker compose run --rm app-dev …`.
+2. Commit inside the project's Docker container:
+   ```bash
+   docker compose run --rm app-dev sh -c \
+     'git config --global --add safe.directory "*" &&
+      git -c user.email=YOU -c user.name=YOU commit --signoff -m "…"'
+   ```
+3. As a last resort, `--no-verify` — but only with explicit user
+   permission, and only after confirming the staged change passes the
+   tests in the project's preferred environment (Docker).
+
+## Concise briefing template
+
+Include this in every multi-agent dispatch where modifications happen
+in parallel:
+
+```
+SHARED REPO HAZARDS:
+- Use bin/rector / vendor/bin/php-cs-fixer / vendor/bin/phpstan
+  directly. Do NOT use `composer rector -- --dry-run` (composer
+  swallows the flag).
+- Do NOT run `git checkout --`, `git restore`, or `git reset --hard`
+  on any file. Use `git stash` for temporary baselines.
+- Before reporting clean: `rm -rf /tmp/phpstan-* var/cache/phpstan`
+  and re-run analyse.
+- After any composer.lock change in your scope: run `composer install`.
+- If pre-commit hooks block your commit: report the hook output, do
+  NOT --no-verify.
+```

--- a/skills/php-modernization/references/php-cs-fixer-deprecations.md
+++ b/skills/php-modernization/references/php-cs-fixer-deprecations.md
@@ -31,3 +31,34 @@ vendor/bin/php-cs-fixer fix --dry-run 2>&1 | grep -A 20 "Detected deprecations"
 `@PER-CS` (without version) is a dynamic alias that resolves to the latest non-deprecated PER-CS version. As of PHP-CS-Fixer 3.54.0, this resolves to PER-CS 2.0 (`@PER-CS2x0`).
 
 Use `@PER-CS` for always-latest behavior, or pin to `@PER-CS2x0` for stability.
+
+## PHP migration sets — current availability
+
+PHP-CS-Fixer ships migration sets ahead of, but staggered behind, the
+PHP version itself. The non-`:risky` set follows release closely; the
+`:risky` variant lags. As of PHP-CS-Fixer **3.95.1**:
+
+| Set | Available | Latest stable |
+|---|---|---|
+| `@PHP80Migration` … `@PHP85Migration` | ✓ | use the one matching your `composer.json`'s PHP constraint |
+| `@PHP80Migration:risky`, `@PHP82Migration:risky` | ✓ | `@PHP82Migration:risky` is the **latest extant `:risky` set** — there is no `@PHP83/84/85Migration:risky` yet |
+
+**Bumping the migration set should track `composer.json`'s PHP
+constraint.** A project on `"php": "^8.5"` should use
+`@PHP85Migration`. If your project is otherwise PHP-8.5-clean,
+bumping the set produces zero diff but sets the right gate.
+
+```bash
+# Inventory what migration sets are installed locally
+vendor/bin/php-cs-fixer list-sets | grep -E "PHP[0-9]+Migration"
+```
+
+## Verifier checks
+
+The verify scripts should detect:
+
+- Deprecated `@PHP8xMigration` aliases (mapping above)
+- A `@PHPxxMigration` set lower than the project's PHP constraint
+  (e.g. `composer.json` has `"php": "^8.5"` but `.php-cs-fixer.dist.php`
+  uses `@PHP83Migration`)
+- `@PSR12` / `@PSR12:risky` (deprecated by `@PER-CS`)

--- a/skills/php-modernization/references/php-cs-fixer-deprecations.md
+++ b/skills/php-modernization/references/php-cs-fixer-deprecations.md
@@ -1,13 +1,21 @@
 # PHP-CS-Fixer Deprecated Rule Set Aliases
 
-## Rule Sets (as of PHP-CS-Fixer 3.50.0+)
+> **Verify against your installed version.** Upstream has shifted on
+> these naming schemes more than once. As of PHP-CS-Fixer 3.95.1 (May
+> 2026) the `@PHP8x*Migration` experiment is **withdrawn** — the
+> non-hyphenated `@PHP80Migration` / `@PHP82Migration` etc. forms are
+> the current, non-deprecated names.
+>
+> Always confirm by running `vendor/bin/php-cs-fixer list-sets` against
+> your locked version.
 
-| Deprecated | Replacement |
-|-----------|-------------|
-| `@PHP80Migration` | `@PHP8x0Migration` |
-| `@PHP80Migration:risky` | `@PHP8x0Migration:risky` |
-| `@PHP81Migration` | `@PHP8x1Migration` |
-| `@PHP82Migration` | `@PHP8x2Migration` |
+## Historical / version-dependent renames
+
+These were tagged deprecated in some 3.5x → 3.6x range and may resurface
+again. Always check `list-sets` output rather than relying on this table.
+
+| Possibly deprecated alias | Possibly preferred form |
+|---|---|
 | `@PHPUnit100Migration:risky` | `@PHPUnit10x0Migration:risky` |
 | `@PER-CS1.0` | `@PER-CS1x0` |
 | `@PER-CS2.0` | `@PER-CS2x0` |
@@ -36,9 +44,10 @@ Use `@PER-CS` for always-latest behavior, or pin to `@PER-CS2x0` for stability.
 
 PHP-CS-Fixer ships migration sets ahead of, but staggered behind, the
 PHP version itself. The non-`:risky` set follows release closely; the
-`:risky` variant lags. As of PHP-CS-Fixer **3.95.1**:
+`:risky` variant lags. As of PHP-CS-Fixer **3.95.1** (May 2026, against
+PHP 8.5 GA):
 
-| Set | Available | Latest stable |
+| Set | Available | Notes |
 |---|---|---|
 | `@PHP80Migration` … `@PHP85Migration` | ✓ | use the one matching your `composer.json`'s PHP constraint |
 | `@PHP80Migration:risky`, `@PHP82Migration:risky` | ✓ | `@PHP82Migration:risky` is the **latest extant `:risky` set** — there is no `@PHP83/84/85Migration:risky` yet |
@@ -47,6 +56,10 @@ PHP version itself. The non-`:risky` set follows release closely; the
 constraint.** A project on `"php": "^8.5"` should use
 `@PHP85Migration`. If your project is otherwise PHP-8.5-clean,
 bumping the set produces zero diff but sets the right gate.
+
+If your installed PHP-CS-Fixer is older than 3.95 (e.g. 3.6x branch),
+the upper bound may be `@PHP83Migration` or `@PHP84Migration` — verify
+with `list-sets`:
 
 ```bash
 # Inventory what migration sets are installed locally
@@ -57,8 +70,11 @@ vendor/bin/php-cs-fixer list-sets | grep -E "PHP[0-9]+Migration"
 
 The verify scripts should detect:
 
-- Deprecated `@PHP8xMigration` aliases (mapping above)
 - A `@PHPxxMigration` set lower than the project's PHP constraint
   (e.g. `composer.json` has `"php": "^8.5"` but `.php-cs-fixer.dist.php`
-  uses `@PHP83Migration`)
-- `@PSR12` / `@PSR12:risky` (deprecated by `@PER-CS`)
+  uses `@PHP83Migration`).
+- A `@PHPxxMigration` set higher than the installed PHP-CS-Fixer
+  supports — the rule set won't resolve.
+- `@PSR12` / `@PSR12:risky` (deprecated by `@PER-CS`).
+- Any rule-set name that produces a "Detected deprecations" warning
+  on dry-run (run the detection command above).

--- a/skills/php-modernization/references/phpunit-modernization.md
+++ b/skills/php-modernization/references/phpunit-modernization.md
@@ -1,0 +1,154 @@
+# PHPUnit Modernization (12 → 13)
+
+PHPUnit 12.5 deprecated and 13 removed several long-standing idioms. The
+biggest blast-radius change for modernization passes is the **strict
+mock-vs-stub distinction**, which routinely produces 100s of "PHPUnit
+notices" and `InvocationStubber::with()` PHPStan errors when the
+distinction isn't honoured.
+
+## Mock vs Stub: the decision that matters
+
+| Object | Created via | Has `->expects(...)` | Has `->with(...)` | Verifies args |
+|---|---|---|---|---|
+| **Stub** | `createStub(X)` | ✗ | ✗ | ✗ — only returns values |
+| **Mock** | `createMock(X)` | ✓ | ✓ (after `expects`) | ✓ |
+| **Mock-as-stub** | `createMock(X)` | ✗ (just `method`) | ✗ in 13 | — was deprecated path |
+
+PHPUnit 12.5 deprecated and 13 removed the "mock-as-stub" pattern
+(`$mock->method('x')->with($arg)->willReturn(...)` without `expects`).
+The chain receiver is now `InvocationStubber`, which has no `with()`.
+
+### Decision tree for migration
+
+```
+Does the test care what argument the call receives?
+├─ NO  → it's a stub
+│       $stub = self::createStub(X::class);
+│       $stub->method('foo')->willReturn($value);
+│
+└─ YES → it's a mock; require expectation
+        $mock = $this->createMock(X::class);
+        $mock->expects(self::once())     // or ::exactly(N), ::atLeastOnce()
+            ->method('foo')
+            ->with($expectedArg)         // ← THIS is the assertion
+            ->willReturn($value);
+```
+
+## Common antipatterns
+
+### ❌ Mechanical `createMock` → `createStub`
+
+The single biggest mistake when chasing the "no expectations were
+configured" notice (1698-occurrence-class). Substituting `createStub`
+**deletes argument verification** if `->with(...)` was present. Always
+inspect: if `->with(...)` is in the chain, it was a mock — promote it
+to `expects()` form, don't strip it.
+
+### ❌ `self::any()` in PHPUnit 13
+
+`PHPUnit\Framework\TestCase::any()` is hard-deprecated
+([phpunit#6461](https://github.com/sebastianbergmann/phpunit/issues/6461))
+and PHPStan flags every call as `method.deprecated`. Use a concrete
+matcher that reflects the test's actual assertion:
+
+| Want | Use |
+|---|---|
+| Verify exactly one call | `self::once()` |
+| Verify at least one call | `self::atLeastOnce()` |
+| Verify no calls | `self::never()` |
+| Verify N calls | `self::exactly(N)` |
+| Just need `with()` to be available without count check | `self::any()` is gone — pick the closest concrete matcher (usually `once()` if the test path invokes the method exactly once) |
+
+In a modernization sweep, `self::once()` is the safe default for sites
+that previously had `->method('x')->with(...)` without `expects()`:
+those sites invoked the method exactly once on the test path (otherwise
+the original test was already broken).
+
+### ❌ `expectNotToPerformAssertions()` with mock expectations
+
+```php
+public function testEarlyReturn(): void
+{
+    $this->expectNotToPerformAssertions();
+    $mock->expects(self::never())->method('save');  // ← THIS counts
+    $service->process(invalidInput: true);
+}
+```
+
+`expects(self::never())` IS an assertion. PHPUnit 12+ flags this as
+risky: "expectsNoAssertions but performed N assertions". Drop the
+`expectNotToPerformAssertions()` — the mock expectation is the proof.
+
+### ❌ Leaving `->with(...)` on stub-style chains
+
+```php
+// Deprecated in 12.5, hard-removed in 13
+$stub->method('foo')->with('x')->willReturn($v);
+```
+
+Either promote to mock (`expects()` form) or drop `with()`. Don't leave
+it on a stub chain.
+
+## When to use `#[AllowMockObjectsWithoutExpectations]`
+
+Apply at **class level** when:
+
+- The same fixture (e.g. `protected ServiceX $service` in `setUp`) is
+  used both as a stub on some tests and a mock on others, and
+- Refactoring `setUp` to per-test creation would yield no semantic gain.
+
+Don't apply as a default escape hatch. The notice exists to push
+genuinely-stub use of `createMock` over to `createStub`.
+
+## Risky test patterns
+
+| Risky message | Fix |
+|---|---|
+| `Test code did not remove its own exception handlers` | A parent (often Symfony `KernelTestCase`) registered one; add `tearDown` that calls `restore_exception_handler()` until the count balances. |
+| `This test did not perform any assertions` | Add the assertion the test name implies, or use `expectNotToPerformAssertions()` (only if no mock expectations either). |
+| `expectsNoAssertions but performed N` | See antipattern above — drop the expects-no-assertions call. |
+
+## PHPStan stub fingerprint
+
+`phpstan/phpstan-phpunit` ships a stub for `MockObject` that's keyed to
+the installed PHPUnit major. After bumping PHPUnit (or after a rebase
+that pulled in such a bump), run:
+
+```bash
+composer install                            # sync vendor
+rm -rf /tmp/phpstan-* var/cache/phpstan     # invalidate phpstan tmpDir
+vendor/bin/phpstan analyse                  # re-run from cold cache
+```
+
+Without the cache flush, local PHPStan can keep reporting clean while
+CI fails — the stale `tmpDir` holds analyses keyed to the old stub.
+
+## Mass-conversion playbook
+
+When a project has 100+ deprecated `->with()` sites:
+
+1. **Inventory**: `grep -rn "->method(.*->with" tests/ --include="*.php"`
+   gives the candidate sites. Don't trust line counts; one site may span
+   multiple lines.
+2. **Read the production caller** for each method. The arg passed at
+   the call site is what `with(...)` should assert. Don't guess.
+3. **Promote, don't strip**: insert `->expects(self::once())` before
+   `->method(...)`. Keep `->with(...)` exactly as it was.
+4. **Verify cold**: clear PHPStan `tmpDir` and re-run, OR run analyze
+   inside Docker if CI uses Docker — local-only verify can lie.
+5. **Run the affected tests** to confirm `once()` matches the actual
+   call count on the test path.
+
+## Verification commands
+
+```bash
+# Notice count (the agent should drive this to 0)
+vendor/bin/phpunit --display-all-issues 2>&1 | grep -E "PHPUnit notice|tests triggered"
+
+# Risky count
+vendor/bin/phpunit 2>&1 | grep -E "Risky:|There (was|were) [0-9]+ risky"
+
+# Cold PHPStan
+rm -rf /tmp/phpstan-* var/cache/phpstan
+vendor/bin/phpstan analyse --no-progress
+```

--- a/skills/php-modernization/references/phpunit-modernization.md
+++ b/skills/php-modernization/references/phpunit-modernization.md
@@ -27,12 +27,17 @@ Does the test care what argument the call receives?
 │       $stub->method('foo')->willReturn($value);
 │
 └─ YES → it's a mock; require expectation
-        $mock = $this->createMock(X::class);
-        $mock->expects(self::once())     // or ::exactly(N), ::atLeastOnce()
+        $mock = self::createMock(X::class);
+        $mock->expects(self::once())     // see "matcher choice" below
             ->method('foo')
             ->with($expectedArg)         // ← THIS is the assertion
             ->willReturn($value);
 ```
+
+`createMock`/`createStub` are static methods on `TestCase`; PHPStan
+flags `$this->createStub(...)` as `staticMethod.dynamicCall`. Use
+`self::` consistently (or migrate the whole file at once if your repo
+convention is `$this->`).
 
 ## Common antipatterns
 
@@ -48,21 +53,26 @@ to `expects()` form, don't strip it.
 
 `PHPUnit\Framework\TestCase::any()` is hard-deprecated
 ([phpunit#6461](https://github.com/sebastianbergmann/phpunit/issues/6461))
-and PHPStan flags every call as `method.deprecated`. Use a concrete
-matcher that reflects the test's actual assertion:
+and PHPStan flags every call as `method.deprecated`. **Pick the matcher
+that matches the test's actual call semantics** — don't blanket-replace
+with `once()`, that adds a strict assertion the original test didn't
+make and will break paths that legitimately invoke the method 0 or 2+
+times.
 
-| Want | Use |
+| Original intent | Use |
 |---|---|
-| Verify exactly one call | `self::once()` |
-| Verify at least one call | `self::atLeastOnce()` |
-| Verify no calls | `self::never()` |
-| Verify N calls | `self::exactly(N)` |
-| Just need `with()` to be available without count check | `self::any()` is gone — pick the closest concrete matcher (usually `once()` if the test path invokes the method exactly once) |
+| "Method must be called exactly once" | `self::once()` |
+| "Method may be called any number of times, including 0" (true `any()`) | `self::atLeast(0)` (== effectively `any` but accepted by PHPStan) — or rethink whether this is a stub, not a mock |
+| "Method must be called at least once" | `self::atLeastOnce()` |
+| "Method must NOT be called" | `self::never()` |
+| "Method must be called exactly N times" | `self::exactly(N)` |
 
-In a modernization sweep, `self::once()` is the safe default for sites
-that previously had `->method('x')->with(...)` without `expects()`:
-those sites invoked the method exactly once on the test path (otherwise
-the original test was already broken).
+For a mass-conversion of legacy `->method('x')->with(...)` chains
+without `expects()` — these were treated as a stub-style call by
+PHPUnit pre-12, and the framework didn't verify count at all.
+`atLeastOnce()` is usually the safest faithful translation; `once()`
+is correct only when you've verified the test path invokes the method
+exactly once.
 
 ### ❌ `expectNotToPerformAssertions()` with mock expectations
 
@@ -116,7 +126,7 @@ that pulled in such a bump), run:
 
 ```bash
 composer install                            # sync vendor
-rm -rf /tmp/phpstan-* var/cache/phpstan     # invalidate phpstan tmpDir
+vendor/bin/phpstan clear-result-cache       # invalidate analysis cache
 vendor/bin/phpstan analyse                  # re-run from cold cache
 ```
 
@@ -149,6 +159,6 @@ vendor/bin/phpunit --display-all-issues 2>&1 | grep -E "PHPUnit notice|tests tri
 vendor/bin/phpunit 2>&1 | grep -E "Risky:|There (was|were) [0-9]+ risky"
 
 # Cold PHPStan
-rm -rf /tmp/phpstan-* var/cache/phpstan
+vendor/bin/phpstan clear-result-cache
 vendor/bin/phpstan analyse --no-progress
 ```

--- a/skills/php-modernization/references/static-analysis-tools.md
+++ b/skills/php-modernization/references/static-analysis-tools.md
@@ -354,12 +354,16 @@ vendor/bin/rector process --clear-cache
 
 | Set | Purpose |
 |-----|---------|
-| `LevelSetList::UP_TO_PHP_83` | PHP version upgrade |
+| `LevelSetList::UP_TO_PHP_85` | PHP version upgrade — bump alongside `composer.json`'s `php` constraint; available from Rector 2.4+ |
 | `SetList::CODE_QUALITY` | Improve code quality |
 | `SetList::DEAD_CODE` | Remove unused code |
 | `SetList::TYPE_DECLARATION` | Add type declarations |
 | `SetList::PRIVATIZATION` | Make code more private |
 | `SetList::EARLY_RETURN` | Convert to early returns |
+
+If your installed Rector predates 2.4, the upper `UP_TO_PHP_*` constant
+will be `UP_TO_PHP_84` or lower — check `vendor/rector/rector/src/Set/ValueObject/LevelSetList.php`
+for what's actually available.
 
 ### CI Integration
 

--- a/skills/php-modernization/references/static-analysis-tools.md
+++ b/skills/php-modernization/references/static-analysis-tools.md
@@ -284,7 +284,11 @@ Rector automates code migrations and refactoring.
 composer require --dev rector/rector
 ```
 
-### Configuration
+### Configuration (modern, composer-based)
+
+Per-version `SymfonySetList::SYMFONY_*` constants are all
+`@deprecated` upstream — they don't handle package differences. The
+modern shape is to let Rector read installed versions from `composer.lock`:
 
 ```php
 <?php
@@ -295,6 +299,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\Symfony\Set\SymfonySetList;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 
 return RectorConfig::configure()
@@ -306,23 +311,34 @@ return RectorConfig::configure()
         __DIR__ . '/src/Kernel.php',
     ])
     ->withSets([
-        LevelSetList::UP_TO_PHP_83,
+        LevelSetList::UP_TO_PHP_85,        // bump alongside composer.json's php constraint
         SetList::CODE_QUALITY,
         SetList::DEAD_CODE,
         SetList::TYPE_DECLARATION,
         SetList::PRIVATIZATION,
         SetList::EARLY_RETURN,
+        SymfonySetList::SYMFONY_CODE_QUALITY,  // still non-deprecated
     ])
+    ->withComposerBased(symfony: true)         // auto-detects Symfony major from composer.lock
+    ->withAttributesSets(symfony: true)        // annotation → attribute migration
     ->withRules([
         AddVoidReturnTypeWhereNoReturnRector::class,
     ]);
 ```
 
+`withComposerBased(symfony: true)` replaces every per-version
+`SymfonySetList::SYMFONY_60`/`SYMFONY_70`/`SYMFONY_80` etc. and
+auto-tracks the installed Symfony major. Same for `doctrine`,
+`phpunit`, `behat` flags on the same call.
+
 ### Usage
 
 ```bash
-# Preview changes (dry run)
+# Preview changes — INVOKE THE BINARY DIRECTLY.
+# `composer rector -- --dry-run` does NOT forward the flag (composer
+# script aliases swallow trailing args) and runs Rector in apply mode.
 vendor/bin/rector process --dry-run
+bin/rector process --dry-run                 # netresearch convention
 
 # Apply changes
 vendor/bin/rector process
@@ -501,3 +517,23 @@ includes:
 ```
 
 Reduce baseline errors over time until reaching zero.
+
+## Cache invalidation hazard
+
+`phpstan.neon`'s `tmpDir` (e.g. `tmpDir: /tmp/phpstan-X`) caches
+analysis results keyed to `vendor/` stubs. After **any** of:
+
+- `composer install` / `composer update`
+- A rebase that pulled in a `phpstan-*` extension or `phpunit` major
+  bump
+- Mass test refactors (mock → stub conversions, etc.)
+
+…the cache may report the OLD shape as clean while CI fails on the new.
+Always purge before final verify:
+
+```bash
+rm -rf /tmp/phpstan-* var/cache/phpstan
+vendor/bin/phpstan analyse --no-progress
+```
+
+Make this part of the agent's verification step, not optional.


### PR DESCRIPTION
## Summary

Two new references and three updates synthesised from a real-world modernization pass on a Symfony 8 / PHP 8.5 project. Multiple parallel sub-agents made decisions that exposed gaps in the skill's existing guidance — this PR captures the lessons so the next run doesn't relearn them.

## What's new

### `references/phpunit-modernization.md` (~6 KB)

Strict mock-vs-stub distinction PHPUnit 12.5/13 introduced, which routinely produces 100s of "PHPUnit notices" and `InvocationStubber::with()` PHPStan errors when the distinction isn't honoured.

- Decision tree: stub (`createStub` + `method->willReturn`) vs mock (`createMock` + `expects(once)->method->with->willReturn`)
- Antipattern: mechanical `createMock` → `createStub` that strips `->with()` argument verification (**1698-occurrence case**)
- `self::any()` hard-deprecated in PHPUnit 13 — substitution table
- `expectNotToPerformAssertions()` + mock expectations is risky
- When `#[AllowMockObjectsWithoutExpectations]` is appropriate vs an escape hatch
- Risky-test reference table
- PHPStan stub-fingerprint cache hazard after PHPUnit bumps
- Mass-conversion playbook

### `references/multi-agent-pitfalls.md` (~6 KB)

Seven empirical hazards when dispatching parallel sub-agents:

1. `composer SCRIPT -- --flag` does NOT forward (rector ran apply-mode while the agent thought dry-run)
2. `git checkout --` mid-multi-agent run wipes sibling agents' uncommitted edits
3. Local PHPStan `tmpDir` cache lies vs CI after vendor changes
4. Vendor skew after rebase pulls a major bump
5. File-scope overlap between concurrent agents
6. Auto-generated files reappearing in the diff
7. Pre-commit hooks running `phpunit` on host PHP that lacks `pdo_mysql`

Closes with a concise briefing template for dispatch prompts.

## What's updated

| File | Change |
|---|---|
| `SKILL.md` | Reference-routing rows for the new files; 3 new hard guardrails; 2 new checklist items |
| `references/static-analysis-tools.md` | Rector example uses `withComposerBased(symfony: true)` + `withAttributesSets(symfony: true)` (per-version `SymfonySetList::SYMFONY_*` are `@deprecated`); bumped `LevelSetList` example to `UP_TO_PHP_85`; warning about `composer rector -- --dry-run`; new "Cache invalidation hazard" section |
| `references/php-cs-fixer-deprecations.md` | "PHP migration sets — current availability" matrix (`@PHP85Migration` exists in 3.95+; `@PHP82Migration:risky` is still the latest `:risky`); verifier-check list to detect migration-set-vs-PHP-constraint mismatch |

## Why now

These specific gaps cost real time on the source modernization run:

- The mock→stub over-strip cost a follow-up commit + 9 reviewer threads on `JiraHttpClientServiceTest`
- The `composer rector --` arg-forwarding bug nearly cost a phase (sibling agent's entity edits silently reverted)
- Local PHPStan reported `[OK] No errors` while CI failed with 136 errors after rebase pulled PHPUnit 13
- The Rector example in this skill still used the deprecated `SymfonySetList::SYMFONY_73` pattern

## Not in this PR (deliberate)

- **`verify_php_project.py` updates** to mechanically detect these failure modes — better as its own PR with eval cases
- **Gitignore guidance for Symfony auto-generated files** — kept as Hazard #6 since it's project-config-dependent

## Test plan

- [x] Markdown lints clean per `.markdownlint-cli2.jsonc` (most pedantic rules disabled in repo config)
- [x] No links to non-existent references
- [x] New content cross-references existing references where appropriate
- [ ] Skill-validation workflow passes on this branch (CI)
