### PR TITLE
chore(release): v1.18.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "php-modernization",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "PHP 8.x modernization patterns with type safety and PHPStan",
   "repository": "https://github.com/netresearch/php-modernization-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Section ordering within a release: **Added → Changed → Deprecated → Remove
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-05-28
+
 This entry collects the cumulative work landed on `main` after the v1.15.1 tag — the agent-harness refocus that turns the skill into an executable contract instead of a static reference bundle. Release notes will be assigned a version when the next tag is cut.
 
 ### Added

--- a/skills/php-modernization/SKILL.md
+++ b/skills/php-modernization/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when modernizing PHP code: PHP 8.1-8.5 features, PSR/PHP-FIG/P
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires php 8.1+, composer."
 metadata:
-  version: "1.17.1"
+  version: "1.18.0"
   repository: "https://github.com/netresearch/php-modernization-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Release **v1.18.0** (minor bump, conventional commits since v1.17.1).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 1.18.0.

Changes since v1.17.1:
- feat(references): add contracts-and-invariants
- 
- Pre/postconditions and invariants on value objects, service
- methods, and aggregates. Splits enforcement by intent: native
- assert() for self-checks (strippable in production via
- zend.assertions=-1), webmozart/assert for always-on caller
- contracts, custom InvariantViolation for crystalline guarantees
- that must crash in production, @phpstan-assert for static
- narrowing.
- 
- Covers PHP 8.4 property hooks as one-site invariant points and
- honest scoping for property-based testing (data providers +
- Infection for the 90%, eris for the 10% where the input space is
- genuinely large). Cross-links immutability-boundaries,
- type-safety, request-dtos, mutation-testing, php-8.4,
- phpstan-compliance.
- 
- Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
- fixup: trim SKILL.md under 500-word cap
- 

After merge: a signed tag `v1.18.0` on `main` triggers the release workflow.