### PR TITLE
feat(PM-43): middleware catch(Throwable) must re-throw framework control-flow exceptions

### DIFF
--- a/skills/php-modernization/checkpoints.yaml
+++ b/skills/php-modernization/checkpoints.yaml
@@ -483,17 +483,17 @@ llm_reviews:
     domain: code-quality
     severity: error
     prompt: |
-      Review all PSR-15 middleware process() methods that contain a
-      catch(Throwable) or catch(Exception) block.
+      Review all PSR-15 middleware process() methods that contain a broad catch
+      block: catch(\Throwable), catch(Throwable), catch(\Exception), catch(Exception),
+      or multi-catch forms like catch(FooException|\Throwable $e).
 
       In TYPO3 and Symfony middleware stacks, certain exceptions are framework
-      control-flow signals — they carry a prepared response and must propagate
-      to the error-handling middleware further up the stack. Swallowing them
-      (logging and continuing) prevents error pages, redirects, and access
-      controls from working correctly.
+      control-flow signals that must propagate to the error-handling middleware
+      further up the stack. Swallowing them (logging and continuing) prevents
+      error pages, redirects, and access controls from working correctly.
 
-      Flag any catch(Throwable) / catch(Exception) block that does NOT re-throw
-      at least the following types before handling the error:
+      Flag any broad catch block that does NOT re-throw at least the following
+      types before handling the error:
 
       TYPO3 projects:
         - TYPO3\CMS\Core\Http\ImmediateResponseException  (carries PSR-7 response, must propagate)
@@ -501,9 +501,10 @@ llm_reviews:
         - TYPO3\CMS\Core\Error\Http\StatusException       (base for 404, 503, etc. — handled by SiteBasedErrorHandlingMiddleware)
 
       Symfony projects:
-        - Symfony\Component\HttpKernel\Exception\HttpExceptionInterface
+        - Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  (carries HTTP status code + headers, must propagate for HttpKernel to render the correct error response)
+        - Symfony\Component\Security\Core\Exception\AccessDeniedException  (used by security firewall to trigger authentication entry point or render access-denied page)
 
-      A correct guard looks like:
+      A correct guard looks like (TYPO3):
         if ($e instanceof ImmediateResponseException
             || $e instanceof PropagateResponseException
             || $e instanceof StatusException
@@ -511,5 +512,12 @@ llm_reviews:
             throw $e;
         }
 
+      Or for Symfony:
+        if ($e instanceof HttpExceptionInterface
+            || $e instanceof AccessDeniedException
+        ) {
+            throw $e;
+        }
+
       Report the file, method, and missing re-throw types for each violation.
-    desc: "PSR-15 middleware catch(Throwable) blocks must re-throw framework control-flow exceptions (ImmediateResponseException, PropagateResponseException, StatusException)"
+    desc: "PSR-15 middleware broad catch(\Throwable) blocks must re-throw framework control-flow exceptions (TYPO3: ImmediateResponseException, PropagateResponseException, StatusException; Symfony: HttpExceptionInterface, AccessDeniedException)"

--- a/skills/php-modernization/checkpoints.yaml
+++ b/skills/php-modernization/checkpoints.yaml
@@ -477,3 +477,39 @@ llm_reviews:
       4. API resources that are mutable when they could be `final readonly` — flag.
       Reference `references/api-platform-edges.md` for the recommended split.
     desc: "API resources should be readonly DTOs, separate from Doctrine entities"
+
+  - id: PM-43
+    type: llm_review
+    domain: code-quality
+    severity: error
+    prompt: |
+      Review all PSR-15 middleware process() methods that contain a
+      catch(Throwable) or catch(Exception) block.
+
+      In TYPO3 and Symfony middleware stacks, certain exceptions are framework
+      control-flow signals — they carry a prepared response and must propagate
+      to the error-handling middleware further up the stack. Swallowing them
+      (logging and continuing) prevents error pages, redirects, and access
+      controls from working correctly.
+
+      Flag any catch(Throwable) / catch(Exception) block that does NOT re-throw
+      at least the following types before handling the error:
+
+      TYPO3 projects:
+        - TYPO3\CMS\Core\Http\ImmediateResponseException  (carries PSR-7 response, must propagate)
+        - TYPO3\CMS\Core\Http\PropagateResponseException  (same)
+        - TYPO3\CMS\Core\Error\Http\StatusException       (base for 404, 503, etc. — handled by SiteBasedErrorHandlingMiddleware)
+
+      Symfony projects:
+        - Symfony\Component\HttpKernel\Exception\HttpExceptionInterface
+
+      A correct guard looks like:
+        if ($e instanceof ImmediateResponseException
+            || $e instanceof PropagateResponseException
+            || $e instanceof StatusException
+        ) {
+            throw $e;
+        }
+
+      Report the file, method, and missing re-throw types for each violation.
+    desc: "PSR-15 middleware catch(Throwable) blocks must re-throw framework control-flow exceptions (ImmediateResponseException, PropagateResponseException, StatusException)"

--- a/skills/php-modernization/checkpoints.yaml
+++ b/skills/php-modernization/checkpoints.yaml
@@ -520,4 +520,4 @@ llm_reviews:
         }
 
       Report the file, method, and missing re-throw types for each violation.
-    desc: "PSR-15 middleware broad catch(\Throwable) blocks must re-throw framework control-flow exceptions (TYPO3: ImmediateResponseException, PropagateResponseException, StatusException; Symfony: HttpExceptionInterface, AccessDeniedException)"
+    desc: 'PSR-15 middleware broad catch(\Throwable) blocks must re-throw framework control-flow exceptions (TYPO3: ImmediateResponseException, PropagateResponseException, StatusException; Symfony: HttpExceptionInterface, AccessDeniedException)'


### PR DESCRIPTION
## Summary

- Adds checkpoint **PM-43** (`middleware-throwable-catch-passthrough`) to the LLM review section
- Flags PSR-15 middleware `process()` methods where `catch(Throwable)` does not re-throw `ImmediateResponseException`, `PropagateResponseException`, or `StatusException` (TYPO3) / `HttpExceptionInterface` (Symfony)

## Root cause (production incident)

`GeoDataMiddleware` had a `catch(Throwable)` wrapping its entire `process()` body, including the `$handler->handle($request)` call for non-responsible requests. When TYPO3's `TypoScriptFrontendController` threw `ServiceUnavailableException` (a `StatusException` subtype) for an unconfigured page type, the middleware swallowed it, logged it, and called `$handler->handle($request)` a second time. This caused TSFE to run twice and bypassed `SiteBasedErrorHandlingMiddleware`, preventing the site's configured `503.html` template from rendering.

The fix required two commits because the first pass only re-threw `ImmediateResponseException` and `PropagateResponseException`, missing that `ServiceUnavailableException` extends `StatusException`, not those classes. PM-43's prompt names all three types explicitly so this hierarchy is checked in one pass.

## Test plan

- [ ] Run checkpoint against a middleware with bare `catch(Throwable) { log; return handler->handle() }` — expect error finding
- [ ] Run against middleware with correct re-throw guard for all three types — expect no finding