### PR TITLE
docs: SAST complexity refactors can drop uncovered branches

### DIFF
--- a/skills/php-modernization/references/static-analysis-tools.md
+++ b/skills/php-modernization/references/static-analysis-tools.md
@@ -582,8 +582,8 @@ the existing unit suite passed — only a human code reviewer caught it.)
 Before trusting green gates on a complexity refactor:
 
 - **Diff the control-flow branches** of the refactored method against the
-  original. Is every `return`, `else`, and early-exit preserved? Count them on
-  both sides.
+  original. Trace every logical path to ensure all outcomes are preserved, even
+  if the structural count of `return` or `else` statements has changed.
 - **Add a unit test for the previously-uncovered branch FIRST**, watch it pass
   against the original, then refactor. A test that only covers the happy path
   cannot protect the fallback you are about to move.

--- a/skills/php-modernization/references/static-analysis-tools.md
+++ b/skills/php-modernization/references/static-analysis-tools.md
@@ -565,3 +565,31 @@ Run quality gates through the project's own runner so the PHP version matches CI
 
 Make "run the gate the way CI runs it" part of the verification step — a
 locally-green cs-fixer/PHPStan is not proof until it has run on CI's toolchain.
+
+## SAST maintainability refactors can silently drop a branch
+
+SAST maintainability/complexity findings — SonarCloud `S3776` (cognitive
+complexity) and `S1142` (too many `return` statements) — are usually "fixed" by
+**extracting** a helper method or **reordering** control flow. That edit is
+**behavior-risky in a way the other gates cannot see**: an extraction can
+silently drop a branch — e.g. a fallback-to-default path taken on an empty or
+invalid response. PHP-CS-Fixer and PHPStan stay green (the shape is still
+type-correct and well-formatted), and a passing unit suite proves nothing if
+that branch was never covered. (Seen in practice: a 2026 complexity cleanup
+extracted a method and lost an empty-response fallback; every static gate and
+the existing unit suite passed — only a human code reviewer caught it.)
+
+Before trusting green gates on a complexity refactor:
+
+- **Diff the control-flow branches** of the refactored method against the
+  original. Is every `return`, `else`, and early-exit preserved? Count them on
+  both sides.
+- **Add a unit test for the previously-uncovered branch FIRST**, watch it pass
+  against the original, then refactor. A test that only covers the happy path
+  cannot protect the fallback you are about to move.
+
+Often the better call is to **accept** subjective complexity findings on
+controller / service / command layers rather than perform a risky extraction.
+Mark them won't-fix in the SAST UI with a short comment explaining why the
+method's structure is intentional — a deliberate "review as safe" beats a
+mechanical refactor that ships a regression.


### PR DESCRIPTION
## Summary

Adds one learning from a cross-session retrospective (2026-06-27) to `references/static-analysis-tools.md`: SAST maintainability/complexity findings — SonarCloud `S3776` (cognitive complexity) and `S1142` (too many returns) — whose fix **extracts or reorders** methods are behavior-risky. An extraction can silently drop a branch (e.g. a fallback-to-default path on an empty/invalid response).

The key insight: PHP-CS-Fixer, PHPStan, and a passing unit suite will **not** catch a dropped branch if that path isn't unit-covered — in a real 2026-06-27 cleanup only a human code reviewer did.

## Guidance added

- Before trusting green gates on a complexity refactor, **diff the control-flow branches** of the refactored method against the original (is every `return`/`else`/early-exit preserved?).
- **Add a unit test for the previously-uncovered branch FIRST**, then refactor.
- Often it's better to **accept** subjective complexity findings on controller/service/command layers (mark won't-fix with a comment) than perform a risky extraction.

## Placement

New section appended to the existing SAST reference `skills/php-modernization/references/static-analysis-tools.md`, which is already linked from `SKILL.md` (Reference routing → "Static analysis"). Matches the file's existing narrative "hazard" style with a seen-in-practice anecdote. SKILL.md is untouched (no bloat, stays under its ~500-word ceiling).

## Version decision

**No version bump.** This is a references-only addition to an already-linked file; SKILL.md, plugin.json, and composer.json are unchanged, so the `check-version-parity` hook stays green (all three remain at 1.19.1).

## Validation

Local `pre-commit` run on the changed file: `markdownlint-cli2` Passed, `validate-skill` (all files) Passed, `check-version-parity` Passed, plus trailing-whitespace/end-of-file/merge-conflict/large-file checks Passed. Commit is signed (ED25519) with Signed-off-by.