### PR TITLE
docs: final-service composition + array-over-regex idiom

### DIFF
--- a/skills/php-modernization/references/core-rules.md
+++ b/skills/php-modernization/references/core-rules.md
@@ -22,6 +22,22 @@ When defining fixed value sets, always use backed enums instead of constants:
 
 When type-hinting dependencies, use PSR interfaces (PSR-3, PSR-6, PSR-7, PSR-11, PSR-14, PSR-18).
 
+## Array Functions Over Regex for Token Lists
+
+When adding/removing specific tokens in a delimited string (CSS classes, scopes), prefer `explode`/`array_filter`/`implode` over `preg_replace`:
+
+```php
+// Bad: trim(preg_replace('/\bfloat-(start|end)\b/', '', $classes)) ?: null
+// Good:
+$kept = array_filter(
+    explode(' ', $classes),
+    static fn (string $c): bool => $c !== '' && !in_array($c, ['float-start', 'float-end'], true),
+);
+$result = $kept !== [] ? implode(' ', $kept) : null;
+```
+
+The `$c !== ''` guard drops empty tokens from leading, trailing, or repeated spaces, so the result has no stray spaces and collapses to `null` when nothing is left. The array form states the intent (keep tokens not in this set) and avoids regex word-boundary and partial-match traps.
+
 ## Scoring Criteria
 
 | Criterion | Requirement |

--- a/skills/php-modernization/references/symfony-patterns.md
+++ b/skills/php-modernization/references/symfony-patterns.md
@@ -126,6 +126,60 @@ final class ApiSubscriber implements EventSubscriberInterface
 }
 ```
 
+### Wrapping a `final` service — compose, don't `->decorate()`
+
+To intercept a `final` upstream service that belongs to a **tagged service
+collection**, do not use Symfony's `->decorate()`. Decoration leaves the inner
+service registered, so with a tagged collection **both** the inner (decorated)
+and outer (decorator) service carry the tag — the collection receives the
+service twice, and that duplicate registration can break the consumer (observed
+on PHP 8.1 with a `phpdoc.guides.directive`-tagged collection).
+
+`final` also rules out subclassing. Compose instead: inject the upstream service
+into your wrapper and delegate to it, then in a compiler pass clear the
+upstream's tag so only the wrapper stays in the collection.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Guides\Directive;
+
+final class MyDirective extends BaseDirective
+{
+    public function __construct(
+        private readonly UpstreamDirective $inner,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function process(BlockContext $blockContext, Directive $directive): ?Node
+    {
+        // intercept / adjust, then delegate
+        return $this->inner->process($blockContext, $directive);
+    }
+}
+```
+
+Clear the tag on the upstream definition in a compiler pass so only the wrapper
+is registered for the collection:
+
+```php
+// CompilerPassInterface::process()
+if ($container->has(UpstreamDirective::class)) {
+    // findDefinition() resolves aliases; getDefinition() would throw on one
+    $container->findDefinition(UpstreamDirective::class)
+        ->clearTag('phpdoc.guides.directive');
+}
+```
+
+`clearTag()` removes only that tag; the upstream service stays in the container,
+so it remains injectable here and for any other consumer. Prefer it over
+`removeDefinition()`, which deletes the service outright and breaks anything else
+that injects it. For a non-`final` service not in a tagged collection, plain
+`->decorate()` is fine.
+
 ## Attribute-Based Routing
 
 ```php


### PR DESCRIPTION
## Summary

Two PHP patterns promoted from local memory: composing a `final` tagged service instead of decorating it, and preferring array functions over regex for token lists.

## Came from

`/retro promote` pass over local memory (2026-07-04), draining a `patterns.md` note upward to the owning skill.

## Change

- **`references/symfony-patterns.md`** — new DI subsection: for a `final` upstream service in a tagged collection, `->decorate()` leaves the inner service registered so the collection gets tagged twice (broke a `phpdoc.guides.directive` collection on PHP 8.1). Documents composing the wrapper by **injecting** the upstream service and delegating, then **clearing its tag** in a compiler pass (`$container->has()` + `findDefinition()` + `clearTag()`, which resolve aliases) so the upstream stays a container service and only its tag is removed — preferred over `removeDefinition()`, which would break other consumers that inject it.
- **`references/core-rules.md`** — new idiom entry: `explode`/`array_filter`/`implode` over `preg_replace` for adding/removing specific tokens in a delimited string, with a `$c !== ''` guard that drops empty tokens.

Two atomic commits, one per pattern.

## Test plan

- [x] `markdownlint-cli2` clean on both changed files
- [x] SAST (Opengrep) green after rebase onto main (incl. #68)
- [x] Both commits GPG-signed and DCO signed-off
