### PR TITLE
fix(template): suppress intentional mutable-action-tag SAST finding

### DIFF
--- a/skills/php-modernization/templates/github-actions/php-modernization.yml
+++ b/skills/php-modernization/templates/github-actions/php-modernization.yml
@@ -6,7 +6,10 @@
 # Consumers should pin third-party actions to a SHA in production. The major
 # tags below (@v2, @v3, @v4, @v6) are convenient defaults but allow upstream
 # changes through; replace with `<owner>/<repo>@<sha> # <tag>` for SLSA-grade
-# supply-chain hygiene.
+# supply-chain hygiene. The `# nosemgrep: github-actions-mutable-action-tag`
+# markers on those lines record that
+# the mutable default is intentional for this template so SAST does not flag
+# it — drop the marker when you pin to a SHA.
 #
 # Local consumption:
 #   cp skills/php-modernization/templates/github-actions/php-modernization.yml \
@@ -45,13 +48,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4  # nosemgrep: github-actions-mutable-action-tag
         with:
           # Infection diff-mode needs the base branch in history.
           fetch-depth: 0
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2  # nosemgrep: github-actions-mutable-action-tag
         with:
           php-version: ${{ inputs.php-version }}
           coverage: none
@@ -61,7 +64,7 @@ jobs:
         run: composer install --no-interaction --prefer-dist --no-progress
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v6  # nosemgrep: github-actions-mutable-action-tag
         with:
           enable-cache: true
 
@@ -79,7 +82,7 @@ jobs:
 
       - name: Upload SARIF to code scanning
         if: ${{ inputs.enable-sarif }}
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v3  # nosemgrep: github-actions-mutable-action-tag
         with:
           sarif_file: php-modernization.sarif
           category: php-modernization
@@ -102,7 +105,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4  # nosemgrep: github-actions-mutable-action-tag
         with:
           name: php-modernization-${{ github.run_id }}
           path: |


### PR DESCRIPTION
## Summary

Suppress the `github-actions-mutable-action-tag` SAST finding on the five `uses: …@vN` lines in the CI template, using inline `# nosemgrep` with a rationale rather than pinning the template to SHAs.

## Why not pin

The template's own header documents the mutable major tags as intentional convenient defaults, with instructions for consumers to pin to a SHA on copy. It is a copy-paste starting point, not a live workflow, so pinning the template contradicts its design and adds Renovate churn. The `# nosemgrep` markers record that the mutable default is deliberate; the header now says to drop the marker when pinning.

## Context

The org SAST (`opengrep --config auto --error --severity WARNING`, from `netresearch/typo3-ci-workflows`) recently began enforcing this rule, so it now fails on every PR to this repo — including the unrelated docs PR #67. This unblocks both.

## Verification

- `opengrep --config auto --severity WARNING skills/` — 5 findings → **0** after the change.
- `yamllint -c .yamllint.yml` on the template — clean.

## Test plan

- [x] Local opengrep re-scan: 0 findings
- [x] yamllint clean
- [x] Commit GPG-signed + DCO signed-off
- [ ] CI green (composer-audit / SAST (Opengrep), lint)
