### PR TITLE
docs(phpunit): coverage driver choice + branch coverage tradeoff

### DIFF
--- a/skills/php-modernization/references/phpunit-modernization.md
+++ b/skills/php-modernization/references/phpunit-modernization.md
@@ -177,7 +177,7 @@ pcov is fast *because* it does less — line coverage only. Switching to pcov fo
 **Enable branch coverage** (needs xdebug — pcov cannot):
 
 ```xml
-<!-- valid in the bundled PHPUnit ≥ 12 schema (phpunit.xsd declares branchCoverage);
+<!-- valid in the bundled PHPUnit 13 schema (phpunit.xsd declares branchCoverage AND pathCoverage);
      some AI review bots wrongly flag it as unsupported — verify against the vendored .xsd -->
 <coverage branchCoverage="true"/>
 ```

--- a/skills/php-modernization/references/phpunit-modernization.md
+++ b/skills/php-modernization/references/phpunit-modernization.md
@@ -162,3 +162,28 @@ vendor/bin/phpunit 2>&1 | grep -E "Risky:|There (was|were) [0-9]+ risky"
 vendor/bin/phpstan clear-result-cache
 vendor/bin/phpstan analyse --no-progress
 ```
+
+## Code coverage: driver choice + branch coverage
+
+Two drivers, different capabilities — pick per need, don't default blindly:
+
+| driver | line | branch | path | also does |
+|--------|:----:|:------:|:----:|-----------|
+| **pcov** | ✓ | ✗ | ✗ | nothing (coverage-only) |
+| **xdebug** | ✓ | ✓ | ✓ | debug, profile, trace |
+
+pcov is fast *because* it does less — line coverage only. Switching to pcov for speed permanently forecloses branch/path coverage. Keep xdebug when you want branch coverage; reach for pcov only for line-only CI where speed dominates.
+
+**Enable branch coverage** (needs xdebug — pcov cannot):
+
+```xml
+<!-- valid in the bundled PHPUnit ≥ 12 schema (phpunit.xsd declares branchCoverage);
+     some AI review bots wrongly flag it as unsupported — verify against the vendored .xsd -->
+<coverage branchCoverage="true"/>
+```
+```bash
+# Cobertura carries branch data (branch-rate / branches-covered) for Codecov; Clover does not
+XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-cobertura cov.xml
+```
+
+**Cost:** xdebug branch coverage instruments every branch decision → **~6× slower** than a plain run; a full unit suite can blow past a 10-min job timeout. Run it off the gating path (nightly / `workflow_dispatch`), never on every PR, and raise that job's `timeout-minutes` accordingly.


### PR DESCRIPTION
Adds a coverage section to `phpunit-modernization.md`: pcov (line-only, fast) vs xdebug (line+branch+path); how to enable branch coverage (`branchCoverage=true` + `--coverage-cobertura`, xdebug-only); the schema validity (some AI review bots wrongly flag `branchCoverage` as unsupported); and the ~6× cost → run off the gating path + raise timeouts.

From a real session: pcov-vs-xdebug came up choosing a CI coverage strategy, and enabling branch coverage on a full unit suite exceeded a 10-min job timeout.