### PR TITLE
chore(release): v1.20.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "php-modernization",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "PHP 8.x modernization patterns with type safety and PHPStan",
   "repository": "https://github.com/netresearch/php-modernization-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/php-modernization/SKILL.md
+++ b/skills/php-modernization/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when modernizing PHP code: PHP 8.1-8.5 features, PSR/PHP-FIG/P
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires php 8.1+, composer."
 metadata:
-  version: "1.20.1"
+  version: "1.20.2"
   repository: "https://github.com/netresearch/php-modernization-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Prepare release v1.20.2 (patch: docs since v1.20.1). Version bump only: plugin.json + SKILL.md (2 files).