### PR TITLE
style: satisfy latest ruff

### DIFF
--- a/skills/php-modernization/scripts/introspect.py
+++ b/skills/php-modernization/scripts/introspect.py
@@ -27,7 +27,7 @@ from typing import Any
 # Sibling-import the shared module. PEP 723 scripts launched via `uv run`
 # don't add their own directory to sys.path, so we add it explicitly.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _common import (  # noqa: E402
+from _common import (
     SCHEMA_VERSION,
     SKILL_ID,
     composer_dep_mentions,

--- a/skills/php-modernization/scripts/modernize_loop.py
+++ b/skills/php-modernization/scripts/modernize_loop.py
@@ -23,9 +23,9 @@ import os
 import subprocess
 import sys
 import time
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Iterable
 
 SCHEMA_VERSION = "1.0.0"
 ARTIFACT_DIR = Path(".build/php-modernization")

--- a/skills/php-modernization/scripts/verify_php_project.py
+++ b/skills/php-modernization/scripts/verify_php_project.py
@@ -26,15 +26,16 @@ import shutil
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 # Sibling-import the shared module. PEP 723 scripts launched via `uv run`
 # don't add their own directory to sys.path, so we add it explicitly.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _common import (  # noqa: E402
+from _common import (
     SCHEMA_VERSION,
     SKILL_ID,
     SKILL_VERSION,


### PR DESCRIPTION
The Lint workflow went red on main after a ruff release tightened its default rule set (the run was green on 2026-07-21, red on the next main push). These are the findings the newer ruff reports, fixed at the source:

- `RUF100` — unused `# noqa: E402` on the sibling imports (removed; E402 is not enabled, so nothing changes)
- `UP035` — `typing.Iterable` → `collections.abc.Iterable` (fitting for this skill in particular)

Verified locally with the exact CI invocation: `ruff check .` → All checks passed; `ruff format --check .` clean.

Note: the root cause is that the shared `skill-repo-skill/validate.yml` runs `uvx ruff` unpinned, so ruff's rolling defaults can turn any skill repo's main red on the next push. Worth pinning ruff there fleet-wide — filed separately.