### PR TITLE
feat(checkpoints): detect self-referencing class constants (PM-44)

### DIFF
--- a/skills/php-modernization/checkpoints.yaml
+++ b/skills/php-modernization/checkpoints.yaml
@@ -218,6 +218,13 @@ mechanical:
     severity: error
     desc: "readonly must not be applied to Doctrine entities or mapped-superclasses (Doctrine hydrates them via reflection-bypassing the constructor). Embeddables are a nuanced case — see references/doctrine-modernization-edges.md"
 
+  # === MECHANICAL REFACTOR SAFETY ===
+  - id: PM-44
+    type: command
+    command: 'D=""; for d in src Classes tests Tests; do [ -d "$d" ] && D="$D $d"; done; [ -z "$D" ] || ! grep -rqP ''const\s+(\w+)\s*=\s*self::\1\b'' $D'
+    severity: error
+    desc: "Self-referencing class constant (const X = self::X) — a fatal error at class-load time, produced by replace-all literal-to-constant extraction that also rewrites the declaration site. Static analysis does not catch it; only executing the file does. Exclude the declaration line when extracting a repeated literal."
+
 llm_reviews:
   # === READONLY CLASS STATIC PROPERTY CHECK ===
   - id: PM-32

--- a/skills/php-modernization/references/migration-strategies.md
+++ b/skills/php-modernization/references/migration-strategies.md
@@ -424,6 +424,39 @@ return $this->legacyParser->parse($input);
 
 ## Anti-Patterns to Avoid
 
+### Replace-All Literal Extraction That Rewrites Its Own Declaration
+
+Bulk-extracting a repeated literal into a constant (the usual fix for SonarQube
+`php:S1192`) is a natural scripted transform: find every `'…'`, replace with
+`self::NAME`. Run naively, the replacement also hits the line that *defines* the
+constant:
+
+```php
+// ❌ what a blind replace-all produces
+private const SMALL_PAYLOAD = self::SMALL_PAYLOAD;   // Fatal: self-referencing constant
+
+// ✅ intended
+private const SMALL_PAYLOAD = '{"a":1}';
+```
+
+**Static analysis does not catch this.** PHPStan at level 10 reports nothing —
+the error is raised by the engine at class-load time, so only *executing* a file
+that loads the class surfaces it. A change set that passes every analyzer can
+still be fatally broken.
+
+Two rules when scripting this class of refactor:
+
+1. **Exclude the declaration line.** Insert the `const` declaration *after*
+   rewriting the usages, or skip any line already matching
+   `const\s+NAME\s*=`.
+2. **Verify by executing, not by analyzing.** Run the test suite (or at minimum
+   `php -l` plus a load of each touched class); a green PHPStan run is not
+   evidence here.
+
+Checkpoint `PM-44` detects the resulting pattern. It generalizes beyond PHP —
+any "extract repeated value to a named constant" transform in any language has
+the same declaration-site hazard.
+
 ### Premature Backwards Compatibility
 
 Don't add backwards compatibility code for features or versions that haven't been released yet:


### PR DESCRIPTION
## Summary

Adds mechanical checkpoint `PM-44` for `const X = self::X` — a fatal-at-load self-referencing constant that no static analyzer reports — plus the anti-pattern section describing the transform that produces it.

## Came from

`/retro` session on 2026-07-30: `3bbf68c3-a30c-4e1e-af38-c97eaf711150`
Finding: routed to `checkpoint` rather than prose because the pattern is a one-line regex — a gate that fails the build outranks a rule asking for care.

- **Symptom:** `Cannot declare self-referencing constant` at runtime, after a scripted extraction of a repeated test payload into a constant. PHPStan level 10 passed the change; only the functional run caught it.
- **Cause:** Blind replace-all of the literal also rewrote the constant's own declaration line, turning `const SMALL_PAYLOAD = '{...}'` into `const SMALL_PAYLOAD = self::SMALL_PAYLOAD`. The engine raises this only when the class is loaded, so analyzers cannot see it.
- **Required behavior:** Exclude the declaration line when scripting literal-to-constant extraction, and verify by executing rather than analyzing.
- **Verification:** `checkpoints.yaml` id `PM-44`.

## Change

- `checkpoints.yaml`: `PM-44`, mechanical, severity `error`
- `references/migration-strategies.md`: anti-pattern section under "Anti-Patterns to Avoid", noting the hazard generalizes to any language's extract-to-constant transform

### Note on the check's shape

The command enumerates existing source directories before grepping. My first version passed all four unconditionally, which is subtly broken: `grep -q` exits **2** when a directory is missing, and negating 2 yields 0 — the check would have silently passed on a real violation in any repo lacking one of `src/`, `Classes/`, `tests/`, `Tests/`. Existing `PM-37`/`PM-39` avoid this by ending their pipelines in `grep -q .`, so no other checkpoint needed the same fix.

## Test plan

- [x] `validate-skill.sh` — 0 errors; `checkpoints.yaml` parses and the command survives YAML escaping intact
- [x] Fires on the real pattern: `const P = self::P` → exit 1
- [x] Does not fire on a legitimate alias: `const A = 'x'; const B = self::A;` → exit 0
- [x] Detects violations under `Tests/` as well as `Classes/` → exit 1
- [x] Repo with no source directories → exit 0 (the case the first version got wrong)
- [x] End-to-end with the command read back out of the parsed YAML, not just as authored
