### PR TITLE
chore(release): v1.21.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "php-modernization",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "description": "PHP 8.x modernization patterns with type safety and PHPStan",
   "repository": "https://github.com/netresearch/php-modernization-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Section ordering within a release: **Added → Changed → Deprecated → Remove
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-08-03
+
+### Added
+
+- `PM-44` checkpoint: detect self-referencing class constants.
+
+### Changed
+
+- Reference guidance updates: fluent wither over new constructor param on consistent-constructor DTOs (PHPStan), `PHP_BINARY` empty under non-CLI SAPIs (Symfony patterns), DEAD_CODE Rector rewrites can change intent, PHP-CS-Fixer pre-push gotchas (cache, unused imports), refreshing a committed lock at the minimum PHP version, reviewing lines Rector adds.
+
+### Fixed
+
+- SonarCloud quality gate: includes-block boundary matching restructured out of an anchored-alternation regex (`python:S5850`/`S6395`); synthetic fixtures excluded from Automatic Analysis via `.sonarcloud.properties` (`text:S8567`).
+
 ## [1.19.0] - 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,8 @@ This entry collects the cumulative work landed on `main` after the v1.15.1 tag â
 
 (historical â€” pre-CHANGELOG)
 
-[Unreleased]: https://github.com/netresearch/php-modernization-skill/compare/v1.19.0...HEAD
+[Unreleased]: https://github.com/netresearch/php-modernization-skill/compare/v1.21.0...HEAD
+[1.21.0]: https://github.com/netresearch/php-modernization-skill/compare/v1.20.2...v1.21.0
 [1.19.0]: https://github.com/netresearch/php-modernization-skill/compare/v1.18.0...v1.19.0
 [1.18.0]: https://github.com/netresearch/php-modernization-skill/compare/v1.15.1...v1.18.0
 [1.15.1]: https://github.com/netresearch/php-modernization-skill/releases/tag/v1.15.1

--- a/skills/php-modernization/SKILL.md
+++ b/skills/php-modernization/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when modernizing PHP code: PHP 8.1-8.5 features, PSR/PHP-FIG/P
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires php 8.1+, composer."
 metadata:
-  version: "1.20.2"
+  version: "1.21.0"
   repository: "https://github.com/netresearch/php-modernization-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Version bump 1.20.2 → 1.21.0 for the v1.21.0 release. Rolls the unreleased changes into the CHANGELOG under 1.21.0.