### PR TITLE
docs: composer package metadata — constraints and per-package verification

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -492,9 +492,9 @@
         "description": "Does not narrow to the locked major, which would be a BC break for consumers"
       },
       {
-        "type": "content_contains",
-        "value": "implement",
-        "description": "Names the implements-vs-consumes test as the reason the permissive range is safe"
+        "type": "content_regex",
+        "value": "(?i)\\b(no|not|never|nothing)\\b[^.]{0,60}\\bimplement",
+        "description": "States that nothing in the package implements the interface — the reason the permissive range is safe, not merely the word"
       }
     ]
   }

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -476,5 +476,26 @@
         "description": "Explains that \\PHP_BINARY is empty under a non-CLI SAPI"
       }
     ]
+  },
+  {
+    "name": "composer-constraint-for-published-package",
+    "prompt": "This monorepo publishes each `packages/*` directory as a standalone Composer package.\n\n`packages/renderer/src/Handler.php` type-hints `Psr\\Log\\LoggerInterface` and reads `Psr\\Log\\LogLevel`. No class in the package implements `LoggerInterface` or extends `AbstractLogger`.\n\n`packages/renderer/composer.json` currently declares:\n\n```json\n{\n    \"require\": {\n        \"php\": \"^8.1\",\n        \"symfony/http-client\": \"^6.4 || ^7.0\"\n    }\n}\n```\n\n`symfony/http-client` requires `psr/log: ^1|^2|^3`. A sibling package in the same repository declares `\"psr/log\": \"^1.0 || ^2.0 || ^3.0\"`. `composer.lock` resolves `psr/log` to 3.0.2.\n\nAdd the missing `psr/log` entry to `packages/renderer/composer.json` and explain the constraint you chose.",
+    "assertions": [
+      {
+        "type": "content_contains",
+        "value": "^1.0 || ^2.0 || ^3.0",
+        "description": "Declares the range the code supports, not the locked major"
+      },
+      {
+        "type": "content_not_contains",
+        "value": "\"psr/log\": \"^3.0\"",
+        "description": "Does not narrow to the locked major, which would be a BC break for consumers"
+      },
+      {
+        "type": "content_contains",
+        "value": "implement",
+        "description": "Names the implements-vs-consumes test as the reason the permissive range is safe"
+      }
+    ]
   }
 ]

--- a/skills/php-modernization/SKILL.md
+++ b/skills/php-modernization/SKILL.md
@@ -41,7 +41,7 @@ allowed-tools:
 | PHP-CS-Fixer deprecations | `references/php-cs-fixer-deprecations.md` |
 | DTOs / VOs / inputs | `references/type-safety.md`, `references/request-dtos.md` |
 | Adapter / registry | `references/adapter-registry-pattern.md` |
-| Multi-version compat | `references/multi-version-adapters.md` |
+| Multi-version compat | `references/multi-version-adapters.md`, `references/composer-package-metadata.md` |
 | Symfony patterns | `references/symfony-patterns.md` |
 | PSR-15 middleware | `references/psr15-middleware-architecture.md` |
 | Doctrine edges | `references/doctrine-modernization-edges.md` |

--- a/skills/php-modernization/checkpoints.yaml
+++ b/skills/php-modernization/checkpoints.yaml
@@ -533,3 +533,43 @@ llm_reviews:
 
       Report the file, method, and missing re-throw types for each violation.
     desc: 'PSR-15 middleware broad catch(\Throwable) blocks must re-throw framework control-flow exceptions (TYPO3: ImmediateResponseException, PropagateResponseException, StatusException; Symfony: HttpExceptionInterface, AccessDeniedException)'
+
+  - id: PM-54
+    type: llm_review
+    domain: code-quality
+    severity: error
+    prompt: |
+      This repository publishes one or more Composer packages (a library, or a
+      monorepo whose packages/* directories are sub-split into standalone
+      packages). Review every dependency constraint that was ADDED or NARROWED
+      in the change under review.
+
+      A constraint in a published package states what the code supports, not
+      what happened to be installed when it was written. Narrowing a range is a
+      breaking change for consumers and cannot ride along in a patch or minor
+      release.
+
+      Flag a constraint when any of these hold:
+
+      1. The range is narrower than the majors that actually provide the symbols
+         the code uses. Example: the code uses only Psr\Log\LoggerInterface and
+         Psr\Log\LogLevel, unchanged across v1, v2 and v3, but the constraint
+         says "^3.0".
+
+      2. The range is narrower than what an existing hard dependency of the same
+         package already permits, so consumers lose a resolution they have today.
+         Example: the package requires symfony/http-client, which permits
+         psr/log ^1|^2|^3, while the new entry says ^3.0.
+
+      3. A sibling package in the same repository declares a wider range for the
+         same dependency, and the difference is not explained.
+
+      Do NOT flag a narrow range when a class in the package IMPLEMENTS an
+      interface of that dependency (implements LoggerInterface, extends
+      AbstractLogger, and equivalents). Implementing binds the package to one
+      major because the signatures differ; consuming does not. In that case the
+      narrow range is correct and the reason belongs in the commit message.
+
+      Report the package, the dependency, the declared range, the range the code
+      actually supports, and which of the three cases applies.
+    desc: 'Dependency constraints in a published package must match what the code supports, never what happened to be installed — narrowing is a BC break for consumers'

--- a/skills/php-modernization/references/composer-package-metadata.md
+++ b/skills/php-modernization/references/composer-package-metadata.md
@@ -33,11 +33,12 @@ Ask whether anything in the package **implements** the interface rather than mer
 Consuming `LoggerInterface` works across majors, because the call sites pass the same arguments. Implementing it does not: PSR-3 v3 declares `string|\Stringable $message` where v1 declares nothing, so a class implementing the interface is bound to one major. The same holds for any interface whose signatures changed between majors.
 
 ```bash
-# The check that decides permissive vs. narrow
-grep -rn "implements LoggerInterface\|extends AbstractLogger" packages/*/src
+# First pass. Not just `implements LoggerInterface`: the name may be fully
+# qualified, sit second in an implements list, or arrive through a trait.
+grep -rnE 'implements[^{]*Logger(Interface|AwareInterface)|extends[^{]*AbstractLogger|use[^;]*Logger(Aware)?Trait' packages/*/src
 ```
 
-Empty result means the permissive range is safe. A hit means the narrow one is required, and the reason belongs in the commit message.
+A hit means the narrow range is required, and the reason belongs in the commit message. An empty result is a first pass, not a verdict — the pattern still misses an interface inherited through a parent class outside `src`, and a trait aliased on import. Read the classes that touch the dependency before settling on the permissive range; the direction that costs consumers a release is a false empty, not a false hit.
 
 ## Verifying a package, not a monorepo
 

--- a/skills/php-modernization/references/composer-package-metadata.md
+++ b/skills/php-modernization/references/composer-package-metadata.md
@@ -34,11 +34,13 @@ Consuming `LoggerInterface` works across majors, because the call sites pass the
 
 ```bash
 # First pass. Not just `implements LoggerInterface`: the name may be fully
-# qualified, sit second in an implements list, or arrive through a trait.
-grep -rnE 'implements[^{]*Logger(Interface|AwareInterface)|extends[^{]*AbstractLogger|use[^;]*Logger(Aware)?Trait' packages/*/src
+# qualified, or sit second in an implements list.
+grep -rnE 'implements[^{]*Logger(Interface|AwareInterface)|extends[^{]*AbstractLogger' packages/*/src
 ```
 
-A hit means the narrow range is required, and the reason belongs in the commit message. An empty result is a first pass, not a verdict — the pattern still misses an interface inherited through a parent class outside `src`, and a trait aliased on import. Read the classes that touch the dependency before settling on the permissive range; the direction that costs consumers a release is a false empty, not a false hit.
+A hit means the narrow range is required, and the reason belongs in the commit message. An empty result is a first pass, not a verdict — the pattern misses an interface inherited through a parent class outside `src`, and an implementation assembled some other way. Read the classes that touch the dependency before settling on the permissive range; the direction that costs consumers a release is a false empty, not a false hit.
+
+`use LoggerTrait` is **not** on that list, and adding it makes the check worse rather than safer: the pattern cannot tell an in-class `use` from a namespace import at the top of the file, and the trait supplies method bodies without implementing the interface — its own methods arrive from whichever major is installed, so they bind nothing. The case that does bind is a class declaring `log()` itself against the trait's abstract, and that is something to read, not to grep.
 
 ## Verifying a package, not a monorepo
 
@@ -47,7 +49,9 @@ In a monorepo the root install merges every dependency graph, so each package's 
 Verify per package, in isolation:
 
 ```bash
-cp -r packages/<name> /tmp/check && cd /tmp/check
+# A fresh directory per run: `cp -r pkg /tmp/check` nests when /tmp/check
+# already exists, and the run then measures the previous copy.
+check="$(mktemp -d)" && cp -r packages/<name>/. "$check" && cd "$check"
 # only production code counts: dev autoload and dev requires are not shipped
 jq 'del(.["autoload-dev"]) | del(.["require-dev"]) | del(.scripts)' composer.json > c && mv c composer.json
 composer install --no-interaction --quiet

--- a/skills/php-modernization/references/composer-package-metadata.md
+++ b/skills/php-modernization/references/composer-package-metadata.md
@@ -1,0 +1,75 @@
+# Composer Package Metadata
+
+**Source:** phpDocumentor/guides -- a monorepo whose ten `packages/*` directories are each published on their own
+**Purpose:** Declare and verify the dependencies of a published package, where the code and the metadata disagree silently
+
+## Two questions, two different answers
+
+A dependency entry answers **what the code supports**. The installed version answers **what someone happened to resolve**. Reading the second and writing it into the first is the mistake this page exists for.
+
+```jsonc
+// psr/log resolved to 3.0.2, so this looked right:
+"psr/log": "^3.0"
+
+// but the code uses only LoggerInterface and LogLevel,
+// unchanged across all three majors, and consumers could
+// already resolve v1 and v2 through symfony/http-client:
+"psr/log": "^1.0 || ^2.0 || ^3.0"
+```
+
+The first form is a **breaking change for consumers**. Somebody pinned to `psr/log` v2 by their framework can no longer install the package, and the change cannot ride along in a patch or minor release. In the case above a maintainer caught it in review: *"Adding `psr/log: ^3.0` to our requirements could be a breaking change for some projects and could therefore not be backported."*
+
+## Deriving the constraint
+
+1. **List the symbols the production code actually uses.** Not the package — the classes, interfaces and functions. `LoggerInterface`, `NullLogger` and `LogLevel` are a different question from "we use PSR-3".
+2. **Find every major that provides them.** If a symbol exists unchanged in v1, v2 and v3, all three are supported.
+3. **Check what your existing hard dependencies already allow.** A package that requires `symfony/http-client` already lets consumers resolve `psr/log: ^1|^2|^3`. Declaring that same range takes nothing away from anyone; declaring less does.
+4. **Read the sibling packages in the same repository.** The established range is usually already written down next door. In the case above, `phpdocumentor/dev-server` carried `^1.0 || ^2.0 || ^3.0` the whole time.
+
+## The one thing that forces a narrow range
+
+Ask whether anything in the package **implements** the interface rather than merely consuming it.
+
+Consuming `LoggerInterface` works across majors, because the call sites pass the same arguments. Implementing it does not: PSR-3 v3 declares `string|\Stringable $message` where v1 declares nothing, so a class implementing the interface is bound to one major. The same holds for any interface whose signatures changed between majors.
+
+```bash
+# The check that decides permissive vs. narrow
+grep -rn "implements LoggerInterface\|extends AbstractLogger" packages/*/src
+```
+
+Empty result means the permissive range is safe. A hit means the narrow one is required, and the reason belongs in the commit message.
+
+## Verifying a package, not a monorepo
+
+In a monorepo the root install merges every dependency graph, so each package's classes are present regardless of what that package declares. Root-level checks are therefore **structurally blind** to per-package defects — a checker run against the root of the repository above reported `There were no symbols found, please check your configuration.`, because the root `composer.json` has no production `autoload` at all.
+
+Verify per package, in isolation:
+
+```bash
+cp -r packages/<name> /tmp/check && cd /tmp/check
+# only production code counts: dev autoload and dev requires are not shipped
+jq 'del(.["autoload-dev"]) | del(.["require-dev"]) | del(.scripts)' composer.json > c && mv c composer.json
+composer install --no-interaction --quiet
+composer-require-checker check --config-file=/path/to/composer-require-checker.json composer.json
+```
+
+Run it once before the change and once after, both against the same baseline, or the two columns are not comparable.
+
+## Reading the output without fooling yourself
+
+Not every unknown symbol is a missing `require`:
+
+| Symbol shape | What it means |
+|---|---|
+| `Vendor\Package\SomeClass` | a genuinely missing `require` |
+| `filter_var`, `mb_strlen`, `ctype_alpha` | a missing `ext-filter` / `ext-mbstring` / `ext-ctype` |
+| `UnknownSymbol`, `template`, `templateArray` | docblock generics — belong in the checker's `symbol-whitelist` |
+| a class from a package listed under `suggest` | deliberately optional; declaring it changes behaviour |
+| a class from a package that requires *this* one | declaring it closes a dependency ring; needs a code change |
+| a v1-only and a v3-only class of the same library | a runtime `class_exists()` switch; unresolvable by construction, whitelist it |
+
+## Two traps that cost real time
+
+**A polyfilled function looks like a version-floor problem and is not.** `mb_str_pad()` exists from PHP 8.3, so a package declaring `php: ^8.1` that calls it looks broken. It is not, if `symfony/polyfill-mbstring` (v1.28+) reaches it — verify by installing the package standalone in a container of the lowest supported PHP version and calling the function. The defect is then an undeclared polyfill, not the PHP floor.
+
+**A pinned checker can abort and look like a pass.** `composer-require-checker` 3.5.1 aborts on `symfony/config` v8 with `Syntax error, unexpected '(', expecting T_VARIABLE`, and `--ignore-parse-errors` does not help. The abort produces empty output that reads exactly like a clean run. Check the exit code and confirm the tool printed a verdict, not nothing.


### PR DESCRIPTION
Adds `references/composer-package-metadata.md`, plus checkpoint PM-54 and an eval case.

## Why

A dependency constraint in a published package states what the code supports. The installed version states what somebody happened to resolve. Reading the second and writing it into the first narrows the range, and narrowing is a breaking change for consumers that cannot ride along in a patch or minor release.

This came out of a review on phpDocumentor/guides: `psr/log` was declared as `^3.0` because the lock resolved 3.0.2, while the code uses only `LoggerInterface` and `LogLevel` — unchanged across all three majors — and consumers could already resolve v1 and v2 through `symfony/http-client`. A maintainer caught it. A sibling package in the same repository had carried `^1.0 || ^2.0 || ^3.0` the whole time.

## What the reference covers

The derivation rule: list the symbols the code uses, find every major that provides them, check what existing hard dependencies already permit, read the sibling packages.

The test that decides permissive versus narrow: does anything **implement** the interface, or does the package only consume it? Consuming works across majors; implementing binds to one, because the signatures differ.

Verification per package rather than at the root. In a monorepo the root install merges every dependency graph, so package-level defects are invisible there — a checker run against the root of the repository above reported `There were no symbols found`, because that root has no production `autoload` at all.

A table for reading checker output, so that PHP extension functions, docblock generics, `suggest`-ed packages and dependency rings do not get turned into requirements.

Two traps that cost real time: a polyfilled function that looks like a version-floor problem, and a pinned checker version that aborts and produces empty output indistinguishable from a clean run.

## Notes

`SKILL.md` is at its 500-line body cap, so the new reference is listed on the existing `Multi-version compat` row rather than as a new row — both are about supporting several majors of a dependency. No other line was touched.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0114KJz3vqq2WWfx4FUdmcss)_


**Review round.** The `implements` grep was widened: it matched neither a fully qualified name, nor a name that is not first in an `implements` list, nor a trait, and six binding shapes in a fixture produced zero hits under the old pattern against six under the new one. Its empty result is now stated as a first pass rather than a verdict, because a false empty here ships the very BC break the page is about.

_Review round assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Txqmch9od8QmcXqPyVJ7bD)_
