### PR TITLE
docs: name the pattern's origin without naming the repository

### DIFF
--- a/skills/php-modernization/references/multi-version-adapters.md
+++ b/skills/php-modernization/references/multi-version-adapters.md
@@ -1,6 +1,6 @@
 # Multi-Version Library Adapter Pattern
 
-**Source:** t3x-nr-image-optimize Extension -- intervention/image v2/v4 compatibility
+**Source:** an image-processing extension supporting intervention/image v2 and v4 side by side
 **Purpose:** Support multiple major versions of a library with incompatible APIs
 
 ## When to Use


### PR DESCRIPTION
The multi-version adapter reference opened with `**Source:** t3x-nr-image-optimize Extension`. Everything after that line is general — the pattern applies to any extension whose dependency ships incompatible major versions — and the repository name is the only part that does not travel.

It matters beyond tidiness. That extension is a target in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals), where this skill is part of the fleet under test, so naming it is a contamination signal that has to be judged and recorded by hand at every fleet pin. Same treatment as netresearch/typo3-testing-skill#132.

The origin still shows: "an image-processing extension supporting intervention/image v2 and v4 side by side" is what a reader needs in order to judge whether the pattern fits their case. One line, no code.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012XjwqvXjw8sA67NoZcoSw7)_