### PR TITLE
chore(release): v1.22.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "php-modernization",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "PHP 8.x modernization patterns with type safety and PHPStan",
   "repository": "https://github.com/netresearch/php-modernization-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Section ordering within a release: **Added → Changed → Deprecated → Remove
 
 ## [Unreleased]
 
+## [1.22.1] - 2026-08-20
+
+### Changed
+
+- The multi-version adapter reference no longer names the repository its example
+  came from. The pattern applies to any extension whose dependency ships
+  incompatible major versions; the repository name was the only part that did
+  not travel, and that repository is an evaluation target in
+  netresearch/agent-system-evals, where this skill is part of the fleet under
+  test ([#94]).
+
+[#94]: https://github.com/netresearch/php-modernization-skill/pull/94
+
 ## [1.22.0] - 2026-08-08
 
 ### Added

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "php-modernization",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "PHP 8.x modernization patterns with type safety and PHPStan",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/php-modernization/SKILL.md
+++ b/skills/php-modernization/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when modernizing PHP code: PHP 8.1-8.5 features, PSR/PHP-FIG/P
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires php 8.1+, composer."
 metadata:
-  version: "1.22.0"
+  version: "1.22.1"
   repository: "https://github.com/netresearch/php-modernization-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Ships the attribution generalisation from #94: the multi-version adapter reference opened with the name of the repository its example came from, and that repository is an evaluation target in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals), where this skill is part of the fleet under test. Naming a target is a contamination signal that has to be judged and recorded by hand at every fleet pin.

No guidance changed — the merged PR was one line. This is the version bump on all three surfaces plus the changelog entry.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012XjwqvXjw8sA67NoZcoSw7)_