### PR TITLE
fix(checkpoints): bring PM-01/PM-02/PM-44 onto the runner contract

### DIFF
--- a/skills/php-modernization/checkpoints.yaml
+++ b/skills/php-modernization/checkpoints.yaml
@@ -12,14 +12,14 @@ skill_id: php-modernization
 mechanical:
   # === PHPSTAN CONFIGURATION ===
   - id: PM-01
-    type: command
-    command: "test -f phpstan.neon || test -f Build/phpstan.neon || test -f Build/phpstan/phpstan.neon || test -f phpstan.neon.dist"
+    type: file_exists
+    target: "{phpstan.neon,Build/phpstan.neon,Build/phpstan/phpstan.neon,phpstan.neon.dist}"
     severity: error
     desc: "PHPStan configuration must exist (phpstan.neon, Build/phpstan.neon, Build/phpstan/phpstan.neon, or phpstan.neon.dist)"
 
   - id: PM-02
     type: command
-    command: 'for f in phpstan.neon Build/phpstan.neon Build/phpstan/phpstan.neon phpstan.neon.dist; do [ -f "$f" ] && grep -qE "^[[:space:]]*level:[[:space:]]*(9|1[0-9]|max)([[:space:]]|$)" "$f" && exit 0; done; exit 1'
+    command: "grep -hE '^[[:space:]]*level:[[:space:]]*(9|1[0-9]|max)([[:space:]]|$)' phpstan.neon Build/phpstan.neon Build/phpstan/phpstan.neon phpstan.neon.dist 2>/dev/null | grep -q ."
     severity: error
     desc: "PHPStan level must be 9 or higher (or max)"
 
@@ -220,8 +220,13 @@ mechanical:
 
   # === MECHANICAL REFACTOR SAFETY ===
   - id: PM-44
-    type: command
-    command: 'D=""; for d in src Classes tests Tests; do [ -d "$d" ] && D="$D $d"; done; [ -z "$D" ] || ! grep -rqP ''const\s+(\w+)\s*=\s*self::\1\b'' $D'
+    type: script
+    command: |
+      D=""
+      for d in src Classes tests Tests; do
+        [ -d "$d" ] && D="$D $d"
+      done
+      [ -z "$D" ] || ! grep -rqP 'const\s+(\w+)\s*=\s*self::\1\b' $D
     severity: error
     desc: "Self-referencing class constant (const X = self::X) — a fatal error at class-load time, produced by replace-all literal-to-constant extraction that also rewrites the declaration site. Static analysis does not catch it; only executing the file does. Exclude the declaration line when extracting a repeated literal."
 


### PR DESCRIPTION
## What

PM-01, PM-02 and PM-44 are rewritten onto the runner's command contract. All three predate the one-liner restrictions and were recorded as `Command rejected` on every assessment run — visible in the nr-llm assessment of 2026-08-26.

| ID | Was | Now |
|---|---|---|
| PM-01 | `\|\|`-chained `test -f` ladder (rejected) | `type: file_exists` with the runner's native brace expansion over the same four candidate paths |
| PM-02 | `for` loop with `;`/`&&` (rejected) | single grep pipeline over the same four paths; `-h` merges matches, tail `grep -q .` is the verdict; missing files only emit suppressed stderr and can never produce a false pass |
| PM-44 | semicolon one-liner with accumulating variable (rejected) | `type: script` block body — the spelling designed for exactly this shape ([automated-assessment-skill#73](https://github.com/netresearch/automated-assessment-skill/pull/73)); screening and execution semantics unchanged |

## Verification

YAML passes yamllint + repo hooks. PM-01/PM-02 semantics checked against nr-llm: `Build/phpstan.neon` exists with a level line, so both pass where the old spellings could not run. PM-44 requires the runner PR above to execute; until then it fails as before rather than silently passing.

_Assisted by sisyphus:x-preview-f-free — session ses_fc4fa40efffed6DRreictQgSlJ_
