### PR TITLE
docs(static-analysis): php:S2003 is a false positive on a value-returning include

### DIFF
--- a/skills/php-modernization/references/static-analysis-tools.md
+++ b/skills/php-modernization/references/static-analysis-tools.md
@@ -667,3 +667,67 @@ controller / service / command layers rather than perform a risky extraction.
 Mark them won't-fix in the SAST UI with a short comment explaining why the
 method's structure is intentional — a deliberate "review as safe" beats a
 mechanical refactor that ships a regression.
+
+## `php:S2003` is a false positive on a value-returning include
+
+SonarCloud's `php:S2003` flags `require`/`include` and asks for the `_once`
+variant. On a config file that ends in `return [...];` and is read **for its
+return value**, that rewrite is a behavior change, not a style fix.
+
+`require` evaluates the file and yields its return value every time it runs.
+`require_once` yields that value only the **first** time the process includes
+that path; every later inclusion of the same path — from anywhere, including a
+different file — short-circuits and yields `bool(true)`:
+
+```php
+// cfg.php ends in:  return ['a' => 1];
+
+$first  = require      'cfg.php';   // array(1) { 'a' => 1 }  ← file included here
+$second = require_once 'cfg.php';   // bool(true)             ← already included
+$third  = require_once 'cfg.php';   // bool(true)
+```
+
+Order is what makes the bug intermittent. `require_once` on a path nothing has
+touched yet *does* return the array; it degrades to `true` only on the repeat.
+So `$config = require_once $path;` in a loader returns the configuration on the
+first call and `true` on the second, and a loader called exactly once passes
+every test — until a second call site, a second request in a long-running
+worker, or another file's own `require_once` of the same config gets there
+first. (Measured on PHP 8.5.10; this is documented `require_once` semantics, not
+a version quirk.)
+
+The consumer then sees `true` where it expected an array. TYPO3's tailor loads
+its packaging config exactly this way and depends on it — `$configuration =
+require $exludeConfigurationFile;` at
+[`src/Service/VersionService.php:243`](https://github.com/TYPO3/tailor/blob/7faa2d2e7e247f309eb8807a30edea1f911aaf07/src/Service/VersionService.php#L243),
+followed two lines later by an `is_array($configuration)` guard that throws.
+Under the `S2003` rewrite that guard starts throwing on the second load.
+
+**Do not apply `S2003` where the include's return value is assigned.** The
+`_once` guard exists to prevent redeclaration; a file that only returns an array
+declares nothing, so there is nothing for it to protect. Plain `require` is
+correct here, and re-reading the file is the point.
+
+Disposing of the finding has two traps of its own:
+
+- **A false-positive mark does not reliably survive a refactor.** Observed: a
+  refactor that reshaped the flagged line brought the finding back under a *new*
+  issue key, while the "won't fix" / "false positive" disposition stayed on the
+  old one — so the rule reappeared on the next analysis with nothing to show
+  that it had already been triaged. Mark the issue **after** the code has
+  reached its final shape, and re-query the project's open issues on the last
+  push instead of trusting a mark set mid-refactor.
+- **A rule that keeps recurring on the same files belongs in a project-level
+  exclusion**, not in one-by-one marks:
+
+```properties
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=php:S2003
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/conf/*.php
+```
+
+Put it in the properties file your analysis mode actually reads: Automatic
+Analysis reads `.sonarcloud.properties`, the CI-based scanner reads
+`sonar-project.properties`, and a project carrying both must keep them in sync.
+The equivalent under **Administration → General Settings → Analysis Scope →
+Ignore Issues on Multiple Criteria** applies in either mode.


### PR DESCRIPTION
SonarCloud `php:S2003` asks for `require_once` in place of `require`. On a config file that ends in `return [...];` and is read for its return value, applying it breaks the code — so the rule needs a documented exception before an agent "fixes" it.

## Measured behaviour

`require` evaluates the file and yields its return value every time it runs. `require_once` yields that value only on the **first** inclusion of that path in the process, and `bool(true)` on every later one — including an inclusion reached from a different file. Measured on PHP 8.5.10, and this is documented `require_once` semantics rather than a version quirk:

```php
// cfg.php ends in:  return ['a' => 1];
$first  = require      'cfg.php';   // array(1) { 'a' => 1 }
$second = require_once 'cfg.php';   // bool(true)
$third  = require_once 'cfg.php';   // bool(true)
```

The snippet in the section is the one I ran, and its output is what the comments state.

## Why it costs time

The failure is intermittent, which is the part worth writing down. `require_once` on a path nothing has touched yet *does* return the array, so a loader called exactly once passes every test; it degrades to `true` only once a second call site, a second request in a long-running worker, or another file's own `require_once` of the same config gets there first. TYPO3's tailor depends on the plain-`require` behaviour — [`src/Service/VersionService.php:243`](https://github.com/TYPO3/tailor/blob/7faa2d2e7e247f309eb8807a30edea1f911aaf07/src/Service/VersionService.php#L243) assigns the require and the `is_array($configuration)` guard two lines down throws when it does not get an array (verified at `7faa2d2`, current `origin/main` of TYPO3/tailor).

## Two disposition notes

The section also records the operational half, which cost as much time as the rule itself: a refactor that reshaped the flagged line brought the finding back under a new issue key while the false-positive mark stayed on the old one, so mark after the final code shape rather than mid-refactor and re-query open issues on the last push. And a rule that keeps recurring on the same files belongs in a `sonar.issue.ignore.multicriteria` exclusion rather than in one-by-one marks. That bullet states the observed effect only — I did not read SonarSource's issue-tracking implementation, so the section names no mechanism for why the key changes. The properties-file guidance is hedged on which file each analysis mode reads, using the split this repo's own `.sonarcloud.properties` already documents, and points at the Analysis Scope UI as the mode-independent route.

## Placement

Appended as a new `##` section to `references/static-analysis-tools.md`, sibling of the existing `## SAST maintainability refactors can silently drop a branch` — that section already covers SonarCloud rule IDs and won't-fix disposition, so the two operational notes belong next to it. Not `migration-strategies.md`: its `S1192` anti-pattern is about a scripted transform corrupting its own output, whereas this one is a rule whose premise is wrong for an input class. No new reference page, no SKILL.md routing change (the routing table already sends "Static analysis" to this file), no `CHANGELOG.md` entry (this repo records changelog entries in dedicated `docs(changelog):` commits at release time, not per content PR). The diff is 63 added lines in one file and nothing else.

## Validation

`bash scripts/verify-harness.sh` — Level 3 COMPLETE, 0 errors, 0 warnings. `pre-commit run --files skills/php-modernization/references/static-analysis-tools.md` — all applicable hooks passed (markdownlint-cli2, trailing whitespace, end-of-file).

One thing I did not verify and did not claim: whether PHPStan or PHP-CS-Fixer would flag the return-type change introduced by the rewrite.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_015Mt4fn33aQDnBw6DhoiJhf)_
