### PR TITLE
test(evals): cover reading a PHP config file without executing it

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -497,5 +497,42 @@
         "description": "States that nothing in the package implements the interface — the reason the permissive range is safe, not merely the word"
       }
     ]
+  },
+  {
+    "name": "read-a-php-config-file-without-running-it",
+    "prompt": "I have to read a configuration array out of a PHP file that users upload. Including it runs their code. I was going to parse it, strip every node that is not a literal with a NodeVisitor, print the rest and evaluate that. Is that sound?",
+    "assertions": [
+      {
+        "type": "content_contains",
+        "value": "ConstExprEvaluator",
+        "description": "Proposes evaluating the expression from the AST instead of executing anything"
+      },
+      {
+        "type": "content_contains",
+        "value": "REMOVE_NODE",
+        "description": "Explains why the strip-then-run approach breaks"
+      },
+      {
+        "type": "content_regex",
+        "value": "(?i)(array|traverseArray).{0,120}(slot|single|parent structure)",
+        "description": "States that REMOVE_NODE is only honoured where the parent structure is an array"
+      }
+    ]
+  },
+  {
+    "name": "const-expr-fallback-must-not-resolve-any-constant",
+    "prompt": "I am evaluating a config array from an untrusted PHP file with nikic/php-parser's ConstExprEvaluator. For constants my fallback does `if (defined($name)) { return constant($name); }`. Anything wrong with that?",
+    "assertions": [
+      {
+        "type": "content_regex",
+        "value": "(?i)(allowlist|allow-list|explicit list|whitelist)",
+        "description": "Requires an explicit list of permitted constants"
+      },
+      {
+        "type": "content_regex",
+        "value": "(?i)(secret|password|api key|credential)",
+        "description": "Names the risk: the uploaded file can name a constant holding a secret"
+      }
+    ]
   }
 ]

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -514,7 +514,7 @@
       },
       {
         "type": "content_regex",
-        "value": "(?i)(array|traverseArray).{0,120}(slot|single|parent structure)",
+        "value": "(?is)((array|traverseArray).{0,120}(slot|single|parent structure)|(slot|single|parent structure).{0,120}(array|traverseArray))",
         "description": "States that REMOVE_NODE is only honoured where the parent structure is an array"
       }
     ]
@@ -532,6 +532,11 @@
         "type": "content_regex",
         "value": "(?i)(secret|password|api key|credential)",
         "description": "Names the risk: the uploaded file can name a constant holding a secret"
+      },
+      {
+        "type": "content_regex",
+        "value": "(?is)(constant\\s*\\(.{0,200}(secret|password|api key|credential)|(secret|password|api key|credential).{0,200}constant\\s*\\()",
+        "description": "Ties the constant() fallback to the disclosure, so naming an allowlist and a secret separately is not enough"
       }
     ]
   }


### PR DESCRIPTION
## Summary

Two evals for the reference merged in #109, so the guidance has something that fails when it regresses. Follow-up to the `/retro` session that produced #109.

## Change

Two entries appended to `evals/evals.json`, in the file's existing shape (`name`, `prompt`, `assertions`).

**`read-a-php-config-file-without-running-it`** — the prompt proposes the strip-then-run approach as if it were sound. The assertions require the answer to reach for `ConstExprEvaluator` over the AST *and* to explain why stripping breaks: `REMOVE_NODE` is honoured only where the parent structure is an array, so a node in a single-node slot throws instead of being removed.

**`const-expr-fallback-must-not-resolve-any-constant`** — the prompt shows `if (defined($name)) { return constant($name); }` and asks whether anything is wrong. The assertions require an explicit allowlist and require the answer to name the risk: an uploaded file can reference a constant holding a secret.

The second one exists because of the review on #109. The reference originally called that fallback harmless on the grounds that it "reads a value, it does not load a class" — framing class loading as the only risk. An eval that only covered the original text would have passed the wrong behaviour.

## Test plan

- [x] `evals.json` parses; the `check json` pre-commit hook passes
- [x] entries match the existing shape — this file uses no ids, and both `content_contains` and `content_regex` are already in use
- [x] commit signed and DCO signed-off
- [ ] reviewer: the regex in the first eval requires "array" or "traverseArray" within 120 chars of "slot"/"single"/"parent structure" — loose enough for varied phrasing, tight enough that a generic "use an AST" answer fails. Worth a second opinion on the window.
