### PR TITLE
docs(changelog): record the unreleased entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Section ordering within a release: **Added → Changed → Deprecated → Remove
 
 ## [Unreleased]
 
+### Added
+
+- `reading-php-config-safely.md`: read a PHP config file without executing it
+
+### Fixed
+
+- `php:S2003` is a false positive on a value-returning include
+- Reading a PHP config handles return-based files, targets the right assignment, and allowlists constants
+
 ## [1.22.3] - 2026-09-03
 
 ### Fixed


### PR DESCRIPTION
The fleet release sweep rolls `[Unreleased]` into the new version heading, and that roll fails on an empty section. This records the entries for the three commits merged since v1.22.3 so the v1.23.0 bump PR can roll them.