### PR TITLE
docs(changelog): record the unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Section ordering within a release: **Added → Changed → Deprecated → Remove
 
 ### Added
 
-- README: the `/plugin install` step the marketplace section was missing, and a "Without a marketplace" section covering the skills-directory route
+- README: the `/plugin install` step missing from the marketplace section, and a "Without a marketplace" section covering the skills-directory route
 - Evals: a case for reading a PHP config file without executing it
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,7 @@ Section ordering within a release: **Added → Changed → Deprecated → Remove
 ### Added
 
 - README: the `/plugin install` step missing from the marketplace section, and a "Without a marketplace" section covering the skills-directory route
-- Evals: a case for reading a PHP config file without executing it
-
-### Fixed
-
-- Evals: a word-order false negative; the case now ties the mechanism to the risk it covers
+- Evals: `read-a-php-config-file-without-running-it` and `const-expr-fallback-must-not-resolve-any-constant`
 
 ## [1.23.0] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Section ordering within a release: **Added → Changed → Deprecated → Remove
 
 ## [Unreleased]
 
+### Added
+
+- README: the `/plugin install` step the marketplace section was missing, and a "Without a marketplace" section covering the skills-directory route
+- Evals: a case for reading a PHP config file without executing it
+
+### Fixed
+
+- Evals: a word-order false negative; the case now ties the mechanism to the risk it covers
+
 ## [1.23.0] - 2026-09-05
 
 ### Added


### PR DESCRIPTION
The `[Unreleased]` section was empty while `main` already carried shipped changes. Two consequences: a release cut from here would publish a version with nothing describing it, and the fleet release driver's changelog roll fails on an empty `[Unreleased]` rather than rolling an empty section — so this blocks the release rather than merely degrading it.

Entries derived from the commits since the last tag, excluding CI-only ones. No code or documentation changes; this only records what is already on `main`.

Opened as preparation for the fleet release sweep.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5)_
