### PR TITLE
fix(review): scope the PHP rules to PHP files via applyTo

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# Scopes the PHP coding rules to PHP files (#116).
+#
+# `knowledge_base.code_guidelines` supplies a guideline document to reviews of
+# every path by default, so PHP rules stated in the root AGENTS.md were being
+# evaluated against Markdown and YAML changes. `applyTo` is the only field that
+# restricts where a document applies — `reviews.path_instructions` only adds
+# guidance for a glob, it cannot subtract a repository-wide one.
+#
+# AGENTS.md is listed explicitly rather than left to the built-in defaults: the
+# schema declares `filePatterns` with `default: []` and documents the defaults
+# in prose, which does not say whether an explicit list extends or replaces
+# them. Naming it keeps it a guideline either way.
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      # Plain-string form: an entry is either a bare pattern or an object that
+      # carries BOTH files and applyTo — the object form with files alone is
+      # schema-invalid, so an unscoped document has to be written like this.
+      - "**/AGENTS.md"
+      - files: "docs/php-rules.md"
+        applyTo: "**/*.php"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,9 @@
 ├── scripts/
 │   ├── test_fixtures.py                      # Golden-snapshot diff runner
 │   └── verify-harness.sh                     # AGENTS.md/docs harness check
-├── docs/ARCHITECTURE.md                      # Architecture overview
+├── docs/
+│   ├── ARCHITECTURE.md                       # Architecture overview
+│   └── php-rules.md                          # PHP coding rules (scoped to **/*.php)
 ├── evals/evals.json                          # Skill evaluation suite
 ├── .claude-plugin/plugin.json                # Plugin manifest
 ├── composer.json                             # Composer package manifest
@@ -84,25 +86,16 @@ The agent contract in [SKILL.md](skills/php-modernization/SKILL.md#hard-guardrai
 
 ## Rules
 
-These govern the PHP this skill guides people to write — `**/*.php`. They do not
-apply to Markdown, YAML, JSON or shell in this repository. Stated because a
-reviewer reading this file as repository-wide guidance has no other way to tell:
-`knowledge_base.code_guidelines` applies a guidelines document to every path, and
-nothing in that setting can scope it.
-
-1. **PHP 8.1+ required** — promotion, readonly, enums, match, attributes, union types.
-2. **Strict types** — `declare(strict_types=1)` in every PHP file.
-3. **DTOs over arrays** — typed objects for structured data, never raw arrays.
-4. **Backed enums** — replace string/int constants for fixed value sets.
-5. **PHPStan ≥ 9** — level 9 minimum, level 10 for new projects, `treatPhpDocTypesAsCertain: false`.
-6. **Static analysis stack** — PHPStan + PHPat + Rector + PHP-CS-Fixer (`@PER-CS`).
-7. **PSR / PER-CS compliance** — see `references/psr-per-compliance.md`.
-8. **Type-hint against PSR interfaces**, not implementations.
+The PHP coding rules live in [docs/php-rules.md](docs/php-rules.md), scoped to
+`**/*.php` via `.coderabbit.yaml`. They are not repeated here: this file is
+supplied to reviews for every path, and a PHP rule stated here is evaluated
+against Markdown and YAML changes too (#116).
 
 ## References
 
 - [SKILL.md](skills/php-modernization/SKILL.md) — agent contract and reference-routing table
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — architecture overview
+- [docs/php-rules.md](docs/php-rules.md) — PHP coding rules, scoped to `**/*.php`
 - [CHANGELOG.md](CHANGELOG.md) — release history
 - [fixtures/README.md](fixtures/README.md) — regression-suite layout and snapshot rules
 - [skills/php-modernization/templates/README.md](skills/php-modernization/templates/README.md) — template consumption guide

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,14 @@ The agent contract in [SKILL.md](skills/php-modernization/SKILL.md#hard-guardrai
 
 ## Rules
 
+These govern the PHP this skill guides people to write — `**/*.php`. They do not
+apply to Markdown, YAML, JSON or shell in this repository. Stated because a
+reviewer reading this file as repository-wide guidance has no other way to tell:
+`knowledge_base.code_guidelines` applies a guidelines document to every path, and
+nothing in that setting can scope it.
+
 1. **PHP 8.1+ required** — promotion, readonly, enums, match, attributes, union types.
-2. **Strict types** — `declare(strict_types=1)` in every file.
+2. **Strict types** — `declare(strict_types=1)` in every PHP file.
 3. **DTOs over arrays** — typed objects for structured data, never raw arrays.
 4. **Backed enums** — replace string/int constants for fixed value sets.
 5. **PHPStan ≥ 9** — level 9 minimum, level 10 for new projects, `treatPhpDocTypesAsCertain: false`.

--- a/docs/php-rules.md
+++ b/docs/php-rules.md
@@ -1,0 +1,19 @@
+# PHP Rules
+
+The coding rules this skill applies to PHP source. Scoped to `**/*.php` through
+`.coderabbit.yaml` (`knowledge_base.code_guidelines.filePatterns[].applyTo`), so
+a review of a Markdown, YAML or shell change does not evaluate them.
+
+They lived in the root `AGENTS.md` until #116: that file is supplied to reviews
+for every path, so "`declare(strict_types=1)` in every file" was read against
+`CHANGELOG.md` and reported as a finding. The rules are unchanged; only where
+they apply is now stated in a place the tooling reads.
+
+1. **PHP 8.1+ required** — promotion, readonly, enums, match, attributes, union types.
+2. **Strict types** — `declare(strict_types=1)` in every PHP file.
+3. **DTOs over arrays** — typed objects for structured data, never raw arrays.
+4. **Backed enums** — replace string/int constants for fixed value sets.
+5. **PHPStan ≥ 9** — level 9 minimum, level 10 for new projects, `treatPhpDocTypesAsCertain: false`.
+6. **Static analysis stack** — PHPStan + PHPat + Rector + PHP-CS-Fixer (`@PER-CS`).
+7. **PSR / PER-CS compliance** — see `../skills/php-modernization/references/psr-per-compliance.md`.
+8. **Type-hint against PSR interfaces**, not implementations.


### PR DESCRIPTION
Closes #116.

`knowledge_base.code_guidelines` supplies a guideline document to reviews of **every** path. The root `AGENTS.md` therefore had its PHP rules evaluated against Markdown, and on #115 a CHANGELOG-only diff drew a `declare(strict_types=1)` finding.

## The change

The PHP rules move to `docs/php-rules.md`, scoped to `**/*.php` through `knowledge_base.code_guidelines.filePatterns[].applyTo`. `AGENTS.md` keeps its repository-wide role and points at them. The rules themselves are unchanged.

## A correction, since the issue and this PR both argued the opposite at first

The issue proposed `reviews.path_instructions`, and my first commit here claimed no field can scope where a guidelines document applies. Both were wrong, and the review caught it. `applyTo` exists and does exactly that — it is in the [published schema](https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json) under `knowledge_base.code_guidelines.filePatterns[]`, described as "Comma-separated glob patterns for files these guidelines applies to". The prose documentation does not mention it, which is where the wrong claim came from; the schema is the source that answers this.

`reviews.path_instructions` really is the wrong lever, but for a narrower reason than I gave: it *adds* guidance for a glob and cannot subtract a repository-wide document.

## Two details the schema decided

`AGENTS.md` is listed explicitly rather than left to the built-in defaults. The schema declares `filePatterns` as `default: []` and documents the default set only in prose, which does not say whether an explicit list extends or replaces it. Naming it keeps it a guideline under either reading.

The object entry form requires **both** `files` and `applyTo`. The first draft wrote `- files: "**/AGENTS.md"` on its own and failed validation, so an unscoped document must use the plain-string form.

## Verification

The config validates clean against the published schema (`jsonschema`, 0 errors) — not just as well-formed YAML. `scripts/verify-harness.sh --status` reports Level 3 (Enforced) complete, 11/11, so the AGENTS.md index and docs-drift gates still hold with the section moved. `markdownlint-cli2` clean.

## Left open deliberately

The fleet-wide question from the issue. Other skill repos carry `AGENTS.md` files of the same shape, but whether a given rule list is actually ambiguous is a per-repo question and none of them has reported the symptom.

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
Assisted-by: claude-code:claude-opus-5
Agent-Session: https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5
