### PR TITLE
docs(type-safety): preg_match returns false, not 0, on malformed UTF-8

### DIFF
--- a/skills/php-modernization/references/type-safety.md
+++ b/skills/php-modernization/references/type-safety.md
@@ -363,17 +363,30 @@ invalid byte makes `preg_match()` return **`false`** — not `0` — so the comm
 shapes silently conflate "no match" with "could not be examined":
 
 ```php
-// WRONG - false == 0, so a byte-damaged subject reads as "no match"
-if (preg_match('/\s/u', $value) === 0) { /* treated as clean */ }
-if (!preg_match('/\s/u', $value))      { /* same bug */ }
+$r = preg_match('/\s/u', $value);   // false on malformed UTF-8
 
-// RIGHT - decide the encoding first, then match
+// WRONG - the match test: false === 1 is false, so a byte-damaged
+// subject reads as "no match" and travels on as if it were clean
+if ($r === 1) { /* has whitespace */ }
+
+// WRONG - conflates false with 0: !false is true, same wrong branch
+if (!preg_match('/\s/u', $value)) { /* "no match" */ }
+
+// ALSO WRONG, differently - the no-match test: false === 0 is false
+// too, so NEITHER branch runs and the error is silently skipped
+if ($r === 0) { /* never reached for a malformed subject */ }
+
+// RIGHT - settle the encoding first, then match
 if (preg_match('//u', $value) !== 1) {
     // not valid UTF-8: reject, log, or transcode - do not fall through
     return null;
 }
 if (preg_match('/\s/u', $value) === 1) { /* now meaningful */ }
 ```
+
+Note the asymmetry: `=== 1` and `!preg_match(...)` take the wrong branch, while
+`=== 0` takes no branch at all. Only the first of those looks like a working
+guard, which is why it is the one that ships.
 
 `'//u'` is an empty pattern with the modifier: it matches any valid UTF-8
 subject and fails on a malformed one, so it is an encoding check that needs no

--- a/skills/php-modernization/references/type-safety.md
+++ b/skills/php-modernization/references/type-safety.md
@@ -356,6 +356,38 @@ class UserRepository implements RepositoryInterface
 
 ## Assertions and Guards
 
+### `preg_match()` returns `false`, not `0`, on malformed UTF-8
+
+With the `/u` modifier PCRE validates the whole subject before matching. An
+invalid byte makes `preg_match()` return **`false`** — not `0` — so the common
+shapes silently conflate "no match" with "could not be examined":
+
+```php
+// WRONG - false == 0, so a byte-damaged subject reads as "no match"
+if (preg_match('/\s/u', $value) === 0) { /* treated as clean */ }
+if (!preg_match('/\s/u', $value))      { /* same bug */ }
+
+// RIGHT - decide the encoding first, then match
+if (preg_match('//u', $value) !== 1) {
+    // not valid UTF-8: reject, log, or transcode - do not fall through
+    return null;
+}
+if (preg_match('/\s/u', $value) === 1) { /* now meaningful */ }
+```
+
+`'//u'` is an empty pattern with the modifier: it matches any valid UTF-8
+subject and fails on a malformed one, so it is an encoding check that needs no
+`mbstring`. `preg_last_error_msg()` names the cause (`Malformed UTF-8
+characters, possibly incorrectly encoded`).
+
+Why it matters beyond the branch: a value that passes an inverted guard keeps
+travelling. Symfony's `UnicodeString` constructor throws
+`InvalidArgumentException` on invalid UTF-8, and `AsciiSlugger` builds one — so
+a single bad byte reaching a slugger aborts the whole run with an exception
+attributed to whatever template called it, naming neither the input nor its
+origin. Validate the encoding where the value enters, and keep the raw value out
+of the log message: it is the one thing that cannot be written safely.
+
 ### Type Guards
 
 ```php


### PR DESCRIPTION
## What

Adds a subsection to `references/type-safety.md`: with the `/u` modifier, `preg_match()` returns **`false`, not `0`**, when the subject is not valid UTF-8.

## Why

PCRE validates the whole subject before matching, so an invalid byte fails the call rather than the match. Both common shapes then read that as "no match" — `=== 0` is false for `false`, and `!preg_match(...)` is true for it. The guard inverts exactly when the input is broken, which is when it is needed.

The reference covers assertions and type guards but said nothing about this, and it is not a cosmetic distinction: a value that slips through keeps travelling. Symfony's `UnicodeString` constructor throws on invalid UTF-8 and `AsciiSlugger` builds one, so a single bad byte reaching a slugger aborts the entire run with an exception attributed to whatever template called it, naming neither the input nor its origin.

## How

The added text gives the two wrong shapes, the check that separates the states — `preg_match('//u', $value) !== 1`, an empty pattern with the modifier, so no `mbstring` dependency — `preg_last_error_msg()` for the diagnosis, and the reason to validate at the boundary rather than at the branch. It also notes that the raw value must stay out of the log message, since it is the one thing that cannot be written safely.

## Testing done

Verified against the running interpreter rather than from documentation:

```
$ php -r 'var_export(preg_match("//u", "feat\xC3ure"));'   # => false
$ php -r 'var_export(preg_match("//u", "feature"));'        # => 1
```

Full pre-commit suite passes.

No version bump: releasing is a separate bump PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance explaining that `preg_match()` returns `false`—not `0`—when malformed UTF-8 is processed with the `/u` modifier.
  - Documented how to distinguish invalid encoding from a valid “no match” result.
  - Added recommendations for validating UTF-8, inspecting error messages, and avoiding raw invalid values in logs.
  - Noted potential downstream exceptions caused by malformed UTF-8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->