### PR TITLE
chore(release): v1.23.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "php-modernization",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "description": "PHP 8.x modernization patterns with type safety and PHPStan",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Section ordering within a release: **Added → Changed → Deprecated → Remove
 
 ## [Unreleased]
 
+## [1.23.2] - 2026-09-12
+
+### Added
+
+- Type safety: `preg_match()` returns `false`, not `0`, when the subject is not valid UTF-8 under `/u` — the two comparison shapes that misread it, the `preg_match('//u', ...)` encoding check that separates the states, and why an unvalidated value aborts a run in `UnicodeString` rather than failing at the branch
+
 ## [1.23.1] - 2026-09-11
 
 ### Added
@@ -171,7 +177,8 @@ This entry collects the cumulative work landed on `main` after the v1.15.1 tag �
 
 (historical — pre-CHANGELOG)
 
-[Unreleased]: https://github.com/netresearch/php-modernization-skill/compare/v1.23.1...HEAD
+[Unreleased]: https://github.com/netresearch/php-modernization-skill/compare/v1.23.2...HEAD
+[1.23.2]: https://github.com/netresearch/php-modernization-skill/compare/v1.23.1...v1.23.2
 [1.23.1]: https://github.com/netresearch/php-modernization-skill/compare/v1.23.0...v1.23.1
 [1.23.0]: https://github.com/netresearch/php-modernization-skill/compare/v1.22.3...v1.23.0
 [1.22.3]: https://github.com/netresearch/php-modernization-skill/compare/v1.22.2...v1.22.3

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "php-modernization",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "description": "PHP 8.x modernization patterns with type safety and PHPStan",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/php-modernization/SKILL.md
+++ b/skills/php-modernization/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when modernizing PHP code: PHP 8.1-8.5 features, PSR/PHP-FIG/P
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires php 8.1+, composer."
 metadata:
-  version: "1.23.1"
+  version: "1.23.2"
   repository: "https://github.com/netresearch/php-modernization-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Version bump only: both `plugin.json` manifests and `SKILL.md`'s `metadata.version` to 1.23.2, plus the CHANGELOG entry.

Patch: the changes since v1.23.1 are `fix:` and `docs:` within an existing reference, with no new file and no new entry in the skill's reference list.

Since v1.23.1:

- **#124** — `references/type-safety.md` gains the `preg_match()` UTF-8 trap. Under `/u`, PCRE validates the whole subject first, so a malformed byte makes the call return `false`, not `0`. The section gives the shapes that misread it, the `preg_match('//u', …)` check that separates "no match" from "could not be examined" without needing mbstring, and why validating at the boundary matters: an unchecked value reaches `UnicodeString` and throws, ending the run with an exception attributed to the caller rather than to the input.
- A follow-up in the same PR corrects which comparison actually misreads the value: `=== 0` takes no branch at all, while `=== 1` and `!preg_match(...)` take the wrong one — and only the first of those looks like a working guard.
- Renovate: pre-commit hook `skill-repo-skill` v2.1.0 and v2.1.1.

Signed tag follows once this is merged.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012Zm6UrYoeXRnucAdTdLRuN)_
